### PR TITLE
Feature/update common intros

### DIFF
--- a/docbook5-book/xml/common_intro_available_doc.xml
+++ b/docbook5-book/xml/common_intro_available_doc.xml
@@ -21,10 +21,12 @@
   <title>Online Documentation and Latest Updates</title>
   <para>
    Documentation for our products is available at
-   <phrase os="sles;sled"><link xlink:href="http://www.suse.com/documentation/"
-   /></phrase><phrase os="osuse"><link xlink:href="http://doc.opensuse.org/"
-   /></phrase>, where you can also find the latest updates, and browse or
-   download the documentation in various formats.
+   <link os="sles;sled" xlink:href="&dsc;"/><link os="osuse"
+   xlink:href="http://doc.opensuse.org/"/>,
+   where you can also find the latest updates, and browse
+   or download the documentation in various formats. The latest
+   documentation updates can usually be found in the English
+   language version.
   </para>
  </note>
  <para>

--- a/docbook5-book/xml/common_intro_feedback.xml
+++ b/docbook5-book/xml/common_intro_feedback.xml
@@ -20,8 +20,8 @@
   </dm:docmanager>
  </info>
  <para>
-  Your feedback and contribution to this documentation is welcome!
-  Several channels are available:
+  We welcome feedback for and contributions to this documentation.
+  There are several channels for this:
  </para>
 
  <variablelist>
@@ -29,13 +29,14 @@
    <term>Service Requests and Support</term>
    <listitem>
     <para>
-     For services and support options available for your product, refer to
+     For services and support options available for your product, see
      <link xlink:href="http://www.suse.com/support/"/>.
     </para>
     <para>
-     To open a service request, you need a subscription at &scc;. Go to
-     <link xlink:href="https://scc.suse.com/support/requests"/>, log in, and click
-     <guimenu>Create New</guimenu>.
+     To open a service request, you need a &suse; subscription registered at
+     &scc;.
+     Go to <link xlink:href="https://scc.suse.com/support/requests"/>, log
+     in, and click <guimenu>Create New</guimenu>.
     </para>
    </listitem>
   </varlistentry>
@@ -44,14 +45,16 @@
    <listitem>
     <para>
      Report issues with the documentation at <link os="sles;sled"
-      xlink:href="https://bugzilla.suse.com/"/><link os="osuse"
-       xlink:href="https://bugzilla.opensuse.org/"/>.
+     xlink:href="https://bugzilla.suse.com/"/><link os="osuse"
+     xlink:href="https://bugzilla.opensuse.org/"/>.
+     Reporting issues requires a Bugzilla account.
+    </para>
+    <para>
      To simplify this process, you can use the <guimenu>Report
-      Documentation Bug</guimenu> links next to headlines in the HTML
+     Documentation Bug</guimenu> links next to headlines in the HTML
      version of this document. These preselect the right product and
      category in Bugzilla and add a link to the current section.
-     You can start typing your bug report right away. A Bugzilla
-     account is required.
+     You can start typing your bug report right away.
     </para>
    </listitem>
   </varlistentry>
@@ -62,7 +65,7 @@
      To contribute to this documentation, use the <guimenu>Edit Source</guimenu>
      links next to headlines in the HTML version of this document. They
      take you to the source code on GitHub, where you can open a pull request.
-     A GitHub account is required.
+     Contributing requires a GitHub account.
     </para>
    </listitem>
   </varlistentry>
@@ -70,11 +73,11 @@
    <term>Mail</term>
    <listitem>
     <para>
-     Alternatively, you can report errors and send feedback concerning the
-     documentation to <email>doc-team@suse.com</email>. Make sure to include the
-     document title, the product version and the publication date of the
-     documentation. Refer to the relevant section number and title (or
-     include the URL) and provide a concise description of the problem.
+     You can also report errors and send feedback concerning the
+     documentation to <email>doc-team@suse.com</email>. Include the
+     document title, the product version, and the publication date of the
+     document. Additionally, include the relevant section number and title (or
+     provide the URL) and provide a concise description of the problem.
     </para>
    </listitem>
   </varlistentry>

--- a/docbook5-book/xml/common_intro_feedback.xml
+++ b/docbook5-book/xml/common_intro_feedback.xml
@@ -12,69 +12,77 @@
  xmlns="http://docbook.org/ns/docbook" version="5.1"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Contact and Feedback</title>
+ <title>Giving Feedback</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>
-
  <para>
-  There are several ways to contact us or give feedback:
+  Your feedback and contribution to this documentation is welcome!
+  Several channels are available:
  </para>
 
  <variablelist>
   <varlistentry os="sles;sled">
-   <term>Support</term>
+   <term>Service Requests and Support</term>
    <listitem>
-    <para os="sles;sled">
+    <para>
      For services and support options available for your product, refer to
      <link xlink:href="http://www.suse.com/support/"/>.
     </para>
-    <para os="osuse">
-     Help for &opensuse; is provided by the community. For more information,
-     see <link xlink:href="https://en.opensuse.org/Portal:Support"/>.
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry os="osuse">
-   <term>Bug Reports</term>
-   <listitem>
-    <para os="sles;sled">
-     To report bugs in &productname;, go to
-     <link xlink:href="https://scc.suse.com/support/requests"/>, log in, and
-     click <guimenu>Create New</guimenu>.
-    </para>
-    <para os="osuse">
-     To report bugs in &productname;, go to <link
-     xlink:href="https://bugzilla.opensuse.org/"/>, log in, and click
-     <guimenu>New</guimenu>.
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry os="sles;sled">
-   <term>Comments</term>
-   <listitem>
     <para>
-     We want to hear your comments about and suggestions for this guide and
-     the other documentation included with this product. Use the User Comments
-     feature at the bottom of each page in the online documentation or go to
-     <link xlink:href="http://www.suse.com/documentation/feedback.html"/> and
-     enter your comments there.
+     To open a service request, you need a subscription at &scc;. Go to
+     <link xlink:href="https://scc.suse.com/support/requests"/>, log in, and click
+     <guimenu>Create New</guimenu>.
     </para>
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term>E-Mail</term>
+   <term>Bug Reports</term>
    <listitem>
     <para>
-     For feedback on the documentation of this product, you can also send a
-     mail to <email>doc-team@suse.com</email>. Make sure to include the
+     Report issues with the documentation at <link os="sles;sled"
+      xlink:href="https://bugzilla.suse.com/"/><link os="osuse"
+       xlink:href="https://bugzilla.opensuse.org/"/>.
+     To simplify this process, you can use the <guimenu>Report
+      Documentation Bug</guimenu> links next to headlines in the HTML
+     version of this document. These preselect the right product and
+     category in Bugzilla and add a link to the current section.
+     You can start typing your bug report right away. A Bugzilla
+     account is required.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry>
+   <term>Contributions</term>
+   <listitem>
+    <para>
+     To contribute to this documentation, use the <guimenu>Edit Source</guimenu>
+     links next to headlines in the HTML version of this document. They
+     take you to the source code on GitHub, where you can open a pull request.
+     A GitHub account is required.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry>
+   <term>Mail</term>
+   <listitem>
+    <para>
+     Alternatively, you can report errors and send feedback concerning the
+     documentation to <email>doc-team@suse.com</email>. Make sure to include the
      document title, the product version and the publication date of the
-     documentation. To report errors or suggest enhancements, provide a
-     concise description of the problem and refer to the respective section
-     number and page (or URL).
+     documentation. Refer to the relevant section number and title (or
+     include the URL) and provide a concise description of the problem.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry os="osuse">
+   <term>Help</term>
+   <listitem>
+    <para>If you need further help on &productname;, see <link
+     xlink:href="https://en.opensuse.org/Portal:Support"/>.
     </para>
    </listitem>
   </varlistentry>

--- a/docbook5-book/xml/generic-entities.ent
+++ b/docbook5-book/xml/generic-entities.ent
@@ -177,6 +177,10 @@
 <!ENTITY dsc-ses        "&dsc;/ses">
 <!ENTITY dsc-suma       "&dsc;/suma">
 
+<!ENTITY beta-www       "https://susedoc.github.io">
+
+<!ENTITY doo            "https://doc.opensuse.org">
+
 
 <!-- PLATFORMS -->
 
@@ -186,12 +190,9 @@
 <!ENTITY amd64          "AMD64">
 <!ENTITY x86-64         "&intel64;/&amd64;">
 
-<!ENTITY arm            "ARM">
+<!ENTITY arm            "Arm">
 <!ENTITY aarch64        "AArch64">
 <!ENTITY arm64          "&arm;&nbsp;&aarch64;">
-
-
-<!ENTITY ipf            "Itanium">
 
 <!ENTITY power          "POWER">
 <!ENTITY ipseries       "&power;">
@@ -199,7 +200,7 @@
 <!ENTITY ppc64le        "ppc64le">
 
 <!ENTITY zseries        "IBM&nbsp;Z">
-<!ENTITY zsystems       "&zsystems;">
+<!ENTITY zsystems       "&zseries;">
 
 
 


### PR DESCRIPTION
Summary of Changes
- updated 'Available Documentation' section
   * removed para about installed doc packages (we rarely have them anymore)
   * added that latest updates can usually be found in EN version
- updated 'Feedback' section
  *  changed title to 'Giving Feedback'
  * 'Bugs and Enhancement Requests' -> 'Service Requests and Support' 
      (to match the content)
  * added separate varlistentry 'Help' on openSUSE
     (to avoid potential confusion with support for business products) 
  * removed Doc comments
  * for Bugzilla, mentioned 'Report Documentation Bugs' links
  * added new varlistentry 'Contributions' and mentioned 'Edit Source' links
- integrated comments by tomschr, dmpop, cjschroder, and sknorr
- some minor rephrasing