### PR TITLE
Move attributes using {product}

### DIFF
--- a/asciidoc-release-notes/adoc/attributes-generic.adoc
+++ b/asciidoc-release-notes/adoc/attributes-generic.adoc
@@ -65,12 +65,6 @@
 :rpi: Raspberry{nbsp}Pi
 :rpireg: {rpi}*
 
-:arm-product: {product} for {arm}
-:rpi-appliance: {arm-product} for the {rpi}
-:this-rpi-appliance: {arm-product} {this-version} for the {rpi}
-:z-product: {product} for IBM Z and LinuxONE
-:power-product: {product} for POWER
-
 // https://aws.amazon.com/trademark-guidelines/
 :amazon-ec2: Amazon{nbsp}EC2
 :amazon-ec2reg: {amazon-ec2}*

--- a/asciidoc-release-notes/adoc/attributes-product.adoc
+++ b/asciidoc-release-notes/adoc/attributes-product.adoc
@@ -3,6 +3,12 @@
 :this-version: 1.0
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {product} {this-version} and important product updates.
 
+:arm-product: {product} for {arm}
+:rpi-appliance: {arm-product} for the {rpi}
+:this-rpi-appliance: {arm-product} {this-version} for the {rpi}
+:z-product: {product} for IBM Z and LinuxONE
+:power-product: {product} for POWER
+
 :doc-url: https://example.com/
 :doc-url-beta: https://example.com/
 :doc-url-source: https://example.com/


### PR DESCRIPTION
Move them to attributes-product.adoc because
they are product-specific, which also fixes
errors caused by them being used before they
are defined.

I have already made this change manually in most repositories so this only syncs the template with the reality.

Fixes #19 