### PR TITLE
attributes: Trigger <productnumber/> change with LIFECYCLE=beta

### DIFF
--- a/asciidoc-release-notes/adoc/attributes-product.adoc
+++ b/asciidoc-release-notes/adoc/attributes-product.adoc
@@ -1,3 +1,15 @@
+// conditionals-begin
+// lifecycle: beta|maintained|unmaintained
+:lifecycle: maintained
+// conditionals-end
+
+ifeval::["{lifecycle}" == "beta"]
+:label-pre: {nbsp}(prerelease)
+endif::[]
+ifeval::["{lifecycle}" != "beta"]
+:label-pre:
+endif::[]
+
 :product: ProductName
 :producta: PN
 
@@ -9,7 +21,7 @@
 :previous-sp: SP0
 :previous-ga: 01
 :previous-version: {this-ga}{nbsp}{previous-sp}
-:this-version: {this-ga}{nbsp}{this-sp}
+:this-version: {this-ga}{nbsp}{this-sp}{label-pre}
 :next-version: {this-ga}{nbsp}{next-sp}
 
 :abstract: This document provides an overview of high-level general features, capabilities, and limitations of {product}{nbsp}{this-version} and important product updates.
@@ -28,11 +40,6 @@
 :rn-url: https://www.suse.com/releasenotes
 
 :resource-library-url: https://www.suse.com/products/server#resources
-
-// conditionals-begin
-// lifecycle: beta|maintained|unmaintained
-:lifecycle: maintained
-// conditionals-end
 
 :copyright-begin: 20XX
 :copyright-end: {docyear}

--- a/asciidoc-release-notes/adoc/release-notes-docinfo.xml
+++ b/asciidoc-release-notes/adoc/release-notes-docinfo.xml
@@ -7,6 +7,6 @@
    </dm:bugtracker>
   </dm:docmanager>
   <releaseinfo>@VERSION@</releaseinfo>
-  <productname>ProductName</productname>
-  <productnumber>1.0</productnumber>
+  <productname>{product}</productname>
+  <productnumber>{this-version}</productnumber>
   <date><?dbtimestamp format="Y-m-d"?></date>


### PR DESCRIPTION
I tested it and it works in OBS so I think it's a good addition to the AsciiDoc RN template.
I've used your original commit message as the commit message.
---

This adds the word "(prerelease)" to <productnumber/> whenever the
document is built with `make pdf LIFECYCLE=beta`.
Surprisingly enough, substitution of attributes in Docinfo files now(?)
works without any fuss,
https://docs.asciidoctor.org/asciidoctor/latest/docinfo/ .

I have not tested this within the context of OBS, I hope it works with
AsciiDoctor version available there, too.

Co-authored-by: sknorr <sknorr@suse.de>