### PR TITLE
db5 ent: Add DocBook 5 entities only kit

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,12 @@ max_line_length = 79
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[*.ent]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
 [*.adoc]
 indent_style = space
 indent_size = 2

--- a/KITS
+++ b/KITS
@@ -1,4 +1,5 @@
 v0.2
 --
 docbook5-book
+docbook5-entities-only
 asciidoc-release-notes

--- a/docbook5-book/xml/generic-entities.ent
+++ b/docbook5-book/xml/generic-entities.ent
@@ -6,414 +6,527 @@
 <!-- PRODUCT-SPECIFIC ENTITIES -->
 
 <!-- Adapt the file product-entities.ent for the needs of your product. -->
-<!ENTITY % product-entities SYSTEM "product-entities.ent">
+<!ENTITY % product-entities     SYSTEM      "product-entities.ent">
 %product-entities;
 
 
 
 <!-- NETWORK-RELATED ENTITIES -->
 
-<!ENTITY % network-entities SYSTEM "network-entities.ent">
+<!ENTITY % network-entities     SYSTEM      "network-entities.ent">
 %network-entities;
 
 
 
 <!-- USERS AND GROUPS -->
 
-<!ENTITY exampleuser          "<systemitem xmlns='http://docbook.org/ns/docbook' class='username'>&exampleuser_plain;</systemitem>">
-<!ENTITY exampleuser_plain    "tux">
-<!ENTITY exampleuserfull      "Tux Linux">
+<!ENTITY exampleuser            "<systemitem xmlns='http://docbook.org/ns/docbook' class='username'>&exampleuser_plain;</systemitem>">
+<!ENTITY exampleuser_plain      "tux">
+<!ENTITY exampleuserfull        "Tux Linux">
 
-<!ENTITY exampleuserII        "<systemitem xmlns='http://docbook.org/ns/docbook' class='username'>&exampleuserII_plain;</systemitem>">
-<!ENTITY exampleuserII_plain  "wilber">
-<!ENTITY exampleuserIIfull    "Wilber Fox">
+<!ENTITY exampleuserII          "<systemitem xmlns='http://docbook.org/ns/docbook' class='username'>&exampleuserII_plain;</systemitem>">
+<!ENTITY exampleuserII_plain    "wilber">
+<!ENTITY exampleuserIIfull      "Wilber Fox">
 
-<!ENTITY exampleuserIII       "<systemitem xmlns='http://docbook.org/ns/docbook' class='username'>exampleuserIII_plain</systemitem>">
-<!ENTITY exampleuserIII_plain "geeko">
-<!ENTITY exampleuserIIIfull   "Suzanne Geeko">
+<!ENTITY exampleuserIII         "<systemitem xmlns='http://docbook.org/ns/docbook' class='username'>exampleuserIII_plain</systemitem>">
+<!ENTITY exampleuserIII_plain   "geeko">
+<!ENTITY exampleuserIIIfull     "Suzanne Geeko">
 
-<!ENTITY examplegroup         "<systemitem xmlns='http://docbook.org/ns/docbook' class='groupname'>users</systemitem>">
-<!ENTITY examplegroup_plain   "users">
+<!ENTITY examplegroup           "<systemitem xmlns='http://docbook.org/ns/docbook' class='groupname'>users</systemitem>">
+<!ENTITY examplegroup_plain     "users">
 
-<!ENTITY rootuser             "<systemitem xmlns='http://docbook.org/ns/docbook' class='username'>root</systemitem>">
+<!ENTITY rootuser               "<systemitem xmlns='http://docbook.org/ns/docbook' class='username'>root</systemitem>">
 
 
 
 <!-- PROMPTS -->
 
-<!ENTITY prompt.root     "<prompt role='root' xmlns='http://docbook.org/ns/docbook'># </prompt>">
-<!ENTITY prompt.user     "<prompt xmlns='http://docbook.org/ns/docbook'>&gt; </prompt>">
-<!ENTITY prompt.sudo     "<prompt xmlns='http://docbook.org/ns/docbook'>&gt; </prompt><command xmlns='http://docbook.org/ns/docbook'>sudo</command> ">
+<!ENTITY prompt.root            "<prompt role='root' xmlns='http://docbook.org/ns/docbook'># </prompt>">
+<!ENTITY prompt.user            "<prompt xmlns='http://docbook.org/ns/docbook'>&gt; </prompt>">
+<!ENTITY prompt.sudo            "<prompt xmlns='http://docbook.org/ns/docbook'>&gt; </prompt><command xmlns='http://docbook.org/ns/docbook'>sudo</command> ">
 
 
 
 <!-- COMPANY -->
 
-<!ENTITY suse          "SUSE">
-<!ENTITY suselinux     "&suse; Linux">
+<!ENTITY suse                   "SUSE">
+<!ENTITY susereg                "SUSE&reg;">
+<!ENTITY suselinux              "&suse; Linux">
 
 
 <!-- SUSE PRODUCTS -->
 
 <!-- SLE -->
-<!ENTITY jeos          "JeOS"><!-- Just enough OS -->
-<!ENTITY leanos        "Installer">
-<!ENTITY sle           "&suse; Linux Enterprise">
-<!ENTITY sled          "&sle; Desktop">
-<!ENTITY slehpc        "&sle; High Performance Computing">
-<!ENTITY slepos        "&sle; Point of Service">
-<!ENTITY slewe         "&sle; Workstation Extension">
-<!ENTITY vmdp          "&sle; Virtual Machine Driver Pack">
-<!ENTITY slelp         "&sle; Live Patching">
-<!ENTITY slert         "&sle; Real Time">
-<!ENTITY sdk           "&sle; Software Development Kit">
-<!ENTITY sles          "&sle; Server">
-<!ENTITY sls           "&sles;">
-<!ENTITY sles4sap      "&sls; for &sap; Applications">
-<!ENTITY s4s           "&sles4sap;">
+<!ENTITY jeos                   "JeOS"><!-- Just enough OS -->
+<!ENTITY leanos                 "Unified Installer">
+<!ENTITY sle                    "&suse; Linux Enterprise">
+<!ENTITY sled                   "&sle; Desktop">
+<!ENTITY slehpc                 "&sle; High Performance Computing">
+<!ENTITY slepos                 "&sle; Point of Service">
+<!ENTITY slewe                  "&sle; Workstation Extension">
+<!ENTITY vmdp                   "&sle; Virtual Machine Driver Pack">
+<!ENTITY slelp                  "&sle; Live Patching">
+<!ENTITY slert                  "&sle; Real Time">
+<!ENTITY sdk                    "&suse; Software Development Kit">
+<!ENTITY sles                   "&sle; Server">
+<!ENTITY sls                    "&sles;">
+<!ENTITY sles4sap               "&sls; for &sap; Applications">
+<!ENTITY s4s                    "&sles4sap;">
+<!ENTITY slem                   "&sle; Micro">
 
-<!-- Cloud & Storage & Emerging Stuff -->
-<!ENTITY cloud         "&suse; &ostack; Cloud">
-<!ENTITY ses           "&suse; Enterprise Storage">
-<!ENTITY caasp         "&suse; CaaS Platform">
-<!ENTITY cap           "&suse; Cloud Application Platform">
 
 <!-- SLE HA -->
-<!ENTITY hasi          "&ha; Extension">
-<!ENTITY sleha         "&sle; &hasi;">
-<!ENTITY hageo         "GEO Clustering for &sleha;">
+<!ENTITY hasi                   "&ha; Extension">
+<!ENTITY sleha                  "&sle; &hasi;">
+<!ENTITY hageo                  "Geo Clustering for &sleha;">
 
 <!-- SUSE Manager -->
-<!ENTITY susemgr       "&suse; Manager">
-<!ENTITY suma          "&susemgr;">
-<!ENTITY susemgrdb     "&suse; Manager with Database">
-<!ENTITY susemgrproxy  "&susemgr; Proxy">
-<!ENTITY smr           "&susemgr; for Retail">
-
-<!-- SUSE Enterprise Storage -->
-<!ENTITY ceph          "Ceph">
-<!ENTITY rook          "Rook">
+<!ENTITY susemgr                "&suse; Manager">
+<!ENTITY suma                   "&susemgr;">
+<!ENTITY susemgrdb              "&suse; Manager with Database">
+<!ENTITY susemgrproxy           "&susemgr; Proxy">
+<!ENTITY smr                    "&susemgr; for Retail">
 
 
 <!-- SUSE PRODUCT ACRONYMS (Scott Corfield via news@suse.com, 2019-03-25) -->
 
-<!ENTITY slea          "SLE">
-<!ENTITY sleda         "SLED">
-<!ENTITY slsa          "SLES">
-<!ENTITY slehaa        "SLE-HA">
-<!ENTITY slehaga       "SLE-HA-GEO"> <!-- This one is not officially defined. -->
-<!ENTITY slehpca       "SLE-HPC">
-<!ENTITY sles4sapa     "SLES-SAP">
-<!ENTITY s4sa          "&sles4sapa;">
-<!ENTITY sleposa       "SLE-POS">
-<!ENTITY slerta        "SLE-RT">
-<!ENTITY slewea        "SLE-WE">
-<!ENTITY slelpa        "SLE-LP">
-<!ENTITY vmdpa         "SLE-VMDP">
-<!ENTITY sesa          "SES">
-<!ENTITY soca          "SOC">
-<!ENTITY capa          "SUSE-CAP">
-<!ENTITY caaspa        "SUSE-CaaSP">
-<!ENTITY caspa         "&caaspa;">
-<!ENTITY sumaa         "SUMA">
-<!ENTITY smra          "SUMA-Retail">
+<!ENTITY slea                   "SLE">
+<!ENTITY sleda                  "SLED">
+<!ENTITY slsa                   "SLES">
+<!ENTITY slehaa                 "SLE-HA">
+<!ENTITY slehaga                "SLE-HA-GEO"> <!-- This one is not officially defined. -->
+<!ENTITY slehpca                "SLE-HPC">
+<!ENTITY sles4sapa              "SLES-SAP">
+<!ENTITY s4sa                   "&sles4sapa;">
+<!ENTITY sleposa                "SLE-POS">
+<!ENTITY slerta                 "SLE-RT">
+<!ENTITY slewea                 "SLE-WE">
+<!ENTITY slelpa                 "SLE-LP">
+<!ENTITY slema                  "&slea; Micro">
+<!ENTITY vmdpa                  "SLE-VMDP">
+<!ENTITY sesa                   "SES">
+<!ENTITY soca                   "SOC">
+<!ENTITY capa                   "SUSE-CAP">
+<!ENTITY caaspa                 "SUSE-CaaSP">
+<!ENTITY caspa                  "&caaspa;">
+<!ENTITY sumaa                  "SUMA">
+<!ENTITY smra                   "SUMA-Retail">
 
 
 <!-- PRODUCT NAMES WITH (R) SIGN (incomplete) -->
 
-<!ENTITY slereg        "&suse;&reg; Linux Enterprise">
-<!ENTITY sledreg       "&slereg; Desktop">
-<!ENTITY slehpcreg     "&slereg; High Performance Computing">
-<!ENTITY slertreg      "&slereg; Real Time">
-<!ENTITY slsreg        "&slereg; Server">
-<!ENTITY sles4sapreg   "&slsreg; for &sap; Applications">
-<!ENTITY susemgrreg    "&suse;&reg; Manager">
+<!ENTITY slereg                 "&suse;&reg; Linux Enterprise">
+<!ENTITY sledreg                "&slereg; Desktop">
+<!ENTITY slehpcreg              "&slereg; High Performance Computing">
+<!ENTITY slertreg               "&slereg; Real Time">
+<!ENTITY slsreg                 "&slereg; Server">
+<!ENTITY sles4sapreg            "&slsreg; for &sap; Applications">
+<!ENTITY slemreg                "&slereg; Micro">
+<!ENTITY susemgrreg             "&suse;&reg; Manager">
 
 <!-- openSUSE VARIANTS -->
 
-<!ENTITY opensuse      "openSUSE">
-<!ENTITY osuse         "&opensuse;">
-<!ENTITY os            "&opensuse;">
-<!ENTITY opensusereg   "openSUSE&reg;">
+<!ENTITY opensuse               "openSUSE">
+<!ENTITY osuse                  "&opensuse;">
+<!ENTITY os                     "&opensuse;">
+<!ENTITY opensusereg            "openSUSE&reg;">
 
-<!ENTITY leap          "&os; Leap">
-<!ENTITY tw            "&os; Tumbleweed">
-<!ENTITY kubic         "&os; Kubic">
-<!ENTITY osuse-micro   "&os; MicroOS">
+<!ENTITY leap                   "&os; Leap">
+<!ENTITY tw                     "&os; Tumbleweed">
+<!ENTITY kubic                  "&os; Kubic">
+<!ENTITY osuse-micro            "&os; MicroOS">
 
 
 
 <!-- SUSE SERVICES -->
 
-<!ENTITY scc           "&suse; Customer Center">
-<!ENTITY sccreg        "&suse;&reg; Customer Center">
-<!ENTITY obs           "Open Build Service">
-<!ENTITY osbs          "&os; Build Service">
-<!ENTITY obsa          "OBS">
-<!ENTITY ph            "&suse; Package Hub">
-<!ENTITY soliddriver   "&suse; SolidDriver">
+<!ENTITY scc                    "&suse; Customer Center">
+<!ENTITY sccreg                 "&suse;&reg; Customer Center">
+<!ENTITY obs                    "Open Build Service">
+<!ENTITY osbs                   "&os; Build Service">
+<!ENTITY obsa                   "OBS">
+<!ENTITY ph                     "&suse; Package Hub">
+<!ENTITY soliddriver            "&suse; SolidDriver">
+<!-- Do not abbreviate "registry" to "reg"! -- &susereg; = SUSE(R) -->
+<!ENTITY suseregistry           "&suse; Registry">
 
 
 
-<!-- 3RD-PARTY -->
+<!-- THIRD-PARTY VENDORS -->
 
-<!ENTITY hpe          "HPE">
-<!ENTITY ostack       "OpenStack">
-<!ENTITY rh           "Red Hat">
-<!ENTITY rhel         "&rh; Enterprise Linux">
-<!ENTITY rhla         "RHEL">
-<!ENTITY sap          "SAP">
-<!ENTITY powerkvm     "PowerKVM">
-<!ENTITY powerlinux   "PowerLinux">
+<!--    &arm; is defined in the PLATFORMS section -->
+<!ENTITY brcm                   "Broadcom">
+<!ENTITY brcmreg                "Broadcom*">
+<!-- Docker trademark policy: Only use &docker; entity for the company or when
+combining with a noun, e.g. "&docker; image". For the engine, always
+use &deng;! -->
+<!ENTITY docker                 "Docker">
+<!ENTITY hpe                    "HPE">
+<!ENTITY ibm                    "IBM">
+<!ENTITY ms                     "Microsoft">
+<!ENTITY msreg                  "<trademark xmlns='http://docbook.org/ns/docbook' class='registered'>&ms;</trademark>">
+<!ENTITY nvidia                 "NVIDIA">
+<!ENTITY rh                     "Red Hat">
+<!ENTITY redhat                 "&rh;">
+<!ENTITY sap                    "SAP">
+<!ENTITY vmware                 "VMware">
+
+
+<!-- THIRD-PARTY PRODUCTS -->
+
+<!ENTITY hana                   "&sap; HANA">
+<!ENTITY macos                  "macOS">
+<!ENTITY macosreg               "<trademark xmlns='http://docbook.org/ns/docbook' class='registered'>&macos;</trademark>">
+<!ENTITY mswin                  "&ms; Windows">
+<!ENTITY mswinreg               "&msreg; <trademark xmlns='http://docbook.org/ns/docbook' class='registered'>Windows</trademark>">
+<!ENTITY netware                "NetWare">
+<!ENTITY netweaver              "&sap; NetWeaver">
+<!ENTITY ostack                 "OpenStack">
+<!ENTITY powerkvm               "PowerKVM">
+<!ENTITY powerlinux             "PowerLinux">
+<!ENTITY rhel                   "&rh; Enterprise Linux">
+<!ENTITY rhla                   "RHEL">
+<!ENTITY rpios                  "Raspberry&nbsp;Pi&nbsp;OS">
 
 
 
 <!-- SLE DVD IMAGE NAMES -->
 
-<!ENTITY allmodules    "SLE-15-Packages">
+<!ENTITY allmodules             "SLE-15-Packages">
 
 
 <!-- URLS -->
 
-<!ENTITY dsc            "https://documentation.suse.com">
-<!ENTITY dsc-sles       "&dsc;/sles">
-<!ENTITY dsc-sled       "&dsc;/sled">
-<!ENTITY dsc-ha         "&dsc;/sle-ha">
-<!ENTITY dsc-sap        "&dsc;/sles-sap">
-<!ENTITY dsc-ses        "&dsc;/ses">
-<!ENTITY dsc-suma       "&dsc;/suma">
-<!ENTITY dsc-caasp      "&dsc;/suse-caasp">
-<!ENTITY dsc-cap        "&dsc;/suse-cap">
-<!ENTITY dsc-soc        "&dsc;/soc">
+<!ENTITY dsc                    "https://documentation.suse.com">
+<!ENTITY dsc-sles               "&dsc;/sles">
+<!ENTITY dsc-sled               "&dsc;/sled">
+<!ENTITY dsc-ha                 "&dsc;/sle-ha">
+<!ENTITY dsc-sap                "&dsc;/sles-sap">
+<!ENTITY dsc-ses                "&dsc;/ses">
+<!ENTITY dsc-suma               "&dsc;/suma">
+<!ENTITY dsc-caasp              "&dsc;/suse-caasp">
+<!ENTITY dsc-cap                "&dsc;/suse-cap">
+<!ENTITY dsc-soc                "&dsc;/soc">
 
 
-<!ENTITY beta-www       "https://susedoc.github.io">
+<!ENTITY beta-www               "https://susedoc.github.io">
 
-<!ENTITY doo            "https://doc.opensuse.org">
+<!ENTITY doo                    "https://doc.opensuse.org">
 
-<!ENTITY sc-rn          "https://www.suse.com/releasenotes">
+<!ENTITY sc-rn                  "https://www.suse.com/releasenotes">
 
-<!ENTITY sccurl         "https://scc.suse.com/">
+<!ENTITY sccurl                 "https://scc.suse.com/">
 
-<!-- PLATFORMS -->
+<!-- HARDWARE ARCHITECTURES AND PLATFORMS -->
 
-<!ENTITY x86            "x86">
+<!ENTITY x86                    "x86">
 
-<!ENTITY intel64        "Intel&nbsp;64">
-<!ENTITY amd64          "AMD64">
-<!ENTITY x86-64         "&intel64;/&amd64;">
+<!ENTITY intel64                "Intel&nbsp;64">
+<!ENTITY amd64                  "AMD64">
+<!ENTITY x86-64                 "&amd64;/&intel64;">
 
-<!ENTITY arm            "Arm">
-<!ENTITY aarch64        "AArch64">
-<!ENTITY arm64          "&arm;&nbsp;&aarch64;">
+<!ENTITY arm                    "Arm">
+<!ENTITY armreg                 "Arm*">
+<!ENTITY armv7                  "Armv7">
+<!ENTITY armv8                  "Armv8">
+<!ENTITY aarch64                "AArch64">
+<!ENTITY arm64                  "&arm;&nbsp;&aarch64;">
+<!ENTITY cortex                 "&arm;&nbsp;Cortex">
+<!ENTITY cortexreg              "&armreg;&nbsp;Cortex*">
+<!ENTITY vc                     "Broadcom VideoCore">
+<!ENTITY vcreg                  "&brcmreg;&nbsp;VideoCore*">
+<!ENTITY vc4reg                 "&vcreg;&nbsp;IV">
 
-<!ENTITY power          "POWER">
-<!ENTITY ppc64le        "ppc64le">
+<!ENTITY rpi                    "Raspberry&nbsp;Pi">
+<!ENTITY rpireg                 "Raspberry&nbsp;Pi*">
+<!ENTITY rpi3                   "Raspberry&nbsp;Pi&nbsp;3">
+<!ENTITY rpi4                   "Raspberry&nbsp;Pi&nbsp;4">
 
-<!ENTITY zseries        "IBM&nbsp;Z">
-<!ENTITY zsystems       "&zseries;">
+<!ENTITY power                  "POWER">
+<!ENTITY ppc64le                "ppc64le">
+
+<!ENTITY zseries                "&ibm;&nbsp;Z">
+<!ENTITY zsystems               "&zseries;">
+<!ENTITY linuxone               "&ibm; LinuxONE">
 
 
 
 <!-- SYSTEM COMPONENTS -->
 
-<!ENTITY aa                "<phrase xmlns='http://docbook.org/ns/docbook'>AppArmor</phrase>">
-<!ENTITY aareg             "<phrase xmlns='http://docbook.org/ns/docbook'>AppArmor&reg;</phrase>">
-<!ENTITY ad                "Active Directory">
-<!ENTITY ada               "AD">
-<!ENTITY aide              "AIDE">
-<!ENTITY ay                "AutoYaST">
-<!ENTITY bcache            "<systemitem xmlns='http://docbook.org/ns/docbook' class='resource'>bcache</systemitem>">
-<!ENTITY chrony            "chrony">
-<!ENTITY chronyc           "<command xmlns='http://docbook.org/ns/docbook'>chronyc</command>">
-<!ENTITY gnome             "GNOME">
-<!ENTITY grub              "GRUB">
-<!ENTITY grub-efi          "GRUB&nbsp;2 for EFI">
-<!ENTITY ha                "High Availability">
-<!ENTITY kdump             "Kdump">
-<!ENTITY kexec             "Kexec">
-<!ENTITY kg                "kGraft">
-<!ENTITY kiwi              "KIWI">
-<!ENTITY kprobes           "Kprobes">
-<!ENTITY krb               "Kerberos">
-<!ENTITY kube              "Kubernetes">
-<!ENTITY libo              "LibreOffice">
-<!ENTITY lvmcache          "<systemitem xmlns='http://docbook.org/ns/docbook' class='resource'>lvmcache</systemitem>">
-<!ENTITY nm                "NetworkManager">
-<!ENTITY ovs               "<phrase role='productname' xmlns='http://docbook.org/ns/docbook'>Open vSwitch</phrase>">
-<!ENTITY pk                "PolKit">
-<!ENTITY rmt               "RMT">
-<!ENTITY rmtool            "Repository Management Tool">
-<!ENTITY salt              "Salt">
-<!ENTITY samba             "Samba">
-<!ENTITY selnx             "SELinux">
-<!ENTITY smaster           "&salt; Master">
-<!ENTITY sminion           "&salt; Minion">
-<!ENTITY sudo              "<command xmlns='http://docbook.org/ns/docbook'>sudo</command>">
-<!ENTITY suseconnect       "SUSEConnect">
-<!ENTITY xgeneric          "X Window System">
-<!ENTITY xvendor           "X.Org">
-<!ENTITY yast              "YaST">
-<!ENTITY yastcc            "<guimenu xmlns='http://docbook.org/ns/docbook'>&yast; Control Center</guimenu>">
-<!ENTITY ycc_runlevel      "Services Manager">
-<!ENTITY yelp              "Help">
+<!ENTITY ds389                  "389 Directory Server">
+<!ENTITY ds389a                 "389 DS">
+<!ENTITY aa                     "<phrase xmlns='http://docbook.org/ns/docbook'>AppArmor</phrase>">
+<!ENTITY aareg                  "<phrase xmlns='http://docbook.org/ns/docbook'>AppArmor&reg;</phrase>">
+<!ENTITY ad                     "Active Directory">
+<!ENTITY ada                    "AD">
+<!ENTITY aide                   "AIDE">
+<!ENTITY ay                     "AutoYaST">
+<!ENTITY bcache                 "<systemitem xmlns='http://docbook.org/ns/docbook' class='resource'>bcache</systemitem>">
+<!ENTITY chrony                 "<systemitem xmlns='http://docbook.org/ns/docbook' class='resource'>chrony</systemitem>">
+<!ENTITY chronyc                "<command xmlns='http://docbook.org/ns/docbook'>chronyc</command>">
+<!ENTITY gnome                  "GNOME">
+<!ENTITY grub                   "GRUB">
+<!ENTITY grub-efi               "GRUB&nbsp;2 for EFI">
+<!ENTITY kdump                  "Kdump">
+<!ENTITY kexec                  "Kexec">
+<!ENTITY kg                     "kGraft">
+<!ENTITY klp                    "Kernel Live Patching">
+<!ENTITY klpa                   "KLP">
+<!ENTITY kiwi                   "KIWI">
+<!ENTITY kprobes                "Kprobes">
+<!ENTITY krb                    "Kerberos">
+<!ENTITY kube                   "Kubernetes">
+<!ENTITY libo                   "LibreOffice">
+<!ENTITY lvmcache               "<systemitem xmlns='http://docbook.org/ns/docbook' class='resource'>lvmcache</systemitem>">
+<!ENTITY nm                     "NetworkManager">
+<!ENTITY ovs                    "<phrase role='productname' xmlns='http://docbook.org/ns/docbook'>Open vSwitch</phrase>">
+<!ENTITY pk                     "PolKit">
+<!ENTITY rmt                    "RMT">
+<!ENTITY rmtool                 "Repository Mirroring Tool">
+<!ENTITY salt                   "Salt">
+<!ENTITY samba                  "Samba">
+<!ENTITY selnx                  "SELinux">
+<!ENTITY smaster                "&salt; Master">
+<!ENTITY sminion                "&salt; Minion">
+<!ENTITY sudo                   "<command xmlns='http://docbook.org/ns/docbook'>sudo</command>">
+<!ENTITY suseconnect            "SUSEConnect">
+<!ENTITY xgeneric               "X Window System">
+<!ENTITY xvendor                "X.Org">
+<!ENTITY yast                   "YaST">
+<!ENTITY yastcc                 "<guimenu xmlns='http://docbook.org/ns/docbook'>&yast; Control Center</guimenu>">
+<!ENTITY ycc_runlevel           "Services Manager">
+<!ENTITY yelp                   "Help">
 
 
 
 <!-- HA -->
 
-<!ENTITY ais           "OpenAIS">
-<!ENTITY corosync      "Corosync">
-<!ENTITY csync         "Csync2">
-<!ENTITY ha            "High Availability">
-<!ENTITY haSetup       "HA Setup">
-<!ENTITY haproxy       "HAProxy">
-<!ENTITY hasetup       "HA setup">
-<!ENTITY haweb         "HA Web Console">
-<!ENTITY hawk          "Hawk">
-<!ENTITY hb            "Heartbeat">
-<!ENTITY hbvs          "Heartbeat 2">
-<!ENTITY lvs           "Linux Virtual Server">
-<!ENTITY pace          "Pacemaker">
-<!ENTITY rear          "ReaR">
-<!ENTITY stonith       "STONITH">
+<!ENTITY ais                    "OpenAIS">
+<!ENTITY corosync               "Corosync">
+<!ENTITY csync                  "Csync2">
+<!ENTITY ha                     "High Availability">
+<!ENTITY haproxy                "HAProxy">
+<!ENTITY hasetup                "HA setup">
+<!ENTITY haweb                  "HA Web Console">
+<!ENTITY hawk                   "Hawk">
+<!ENTITY hb                     "Heartbeat">
+<!ENTITY hbvs                   "Heartbeat 2">
+<!ENTITY lvs                    "Linux Virtual Server">
+<!ENTITY pace                   "Pacemaker">
+<!ENTITY rear                   "ReaR">
+<!ENTITY stonith                "STONITH">
+
+
+
+<!-- SLES FOR SAP -->
+
+<!ENTITY sapconf       "<literal xmlns='http://docbook.org/ns/docbook'>sapconf</literal>">
+<!ENTITY saptune        "<command xmlns='http://docbook.org/ns/docbook'>saptune</command>">
+
+
+
+<!-- CONTAINERS -->
+
+<!ENTITY deng                   "&docker; Open Source Engine">
+<!ENTITY dhub                   "&docker; Hub">
+<!ENTITY dreg                   "&docker; Registry">
+<!ENTITY lxc                    "LXC">
+<!ENTITY podman                 "Podman">
+<!ENTITY buildah                "Buildah">
+<!ENTITY k8s                    "Kubernetes">
 
 
 
 <!-- VIRTUALIZATION -->
 
-<!ENTITY docker         "Docker">
-<!ENTITY dom0           "Dom0">
-<!ENTITY esx            "&vmware; ESX">
-<!ENTITY hyperv         "&ms; Hyper-V">
-<!ENTITY kvm            "KVM">
-<!ENTITY libvirt        "<systemitem xmlns='http://docbook.org/ns/docbook' class='library'>libvirt</systemitem>">
-<!ENTITY lxc            "LXC">
-<!ENTITY ms             "Microsoft">
-<!ENTITY mswin          "&ms; Windows">
-<!ENTITY pciback        "PCI Pass-Through">
-<!ENTITY qemu           "QEMU">
-<!ENTITY qemusystemarch "<command xmlns='http://docbook.org/ns/docbook'>qemu-system-<replaceable>ARCH</replaceable></command>">
-<!ENTITY usbback        "USB Pass-Through">
-<!ENTITY vbox           "Virtual Box">
-<!ENTITY vgaback        "VGA Pass-Through">
-<!ENTITY vmguest        "VM Guest">
-<!ENTITY vmhost         "VM Host Server">
-<!ENTITY vmm            "Virtual Machine Manager">
-<!ENTITY vmware         "VMware">
-<!ENTITY vmware         "VMware">
-<!ENTITY xcat          "xCAT">
-<!ENTITY xen            "Xen">
-<!ENTITY xenreg         "Xen&reg;">
-<!ENTITY xenstore       "XenStore">
+<!ENTITY dom0                   "Dom0">
+<!ENTITY esx                    "&vmware; ESX">
+<!ENTITY gpuback                "GPU Pass-Through">
+<!ENTITY hyperv                 "&ms; Hyper-V">
+<!ENTITY kvm                    "KVM">
+<!ENTITY libvirt                "<systemitem xmlns='http://docbook.org/ns/docbook' class='library'>libvirt</systemitem>">
+<!ENTITY pciback                "PCI Pass-Through">
+<!ENTITY qemu                   "QEMU">
+<!ENTITY qemusystemarch         "<command xmlns='http://docbook.org/ns/docbook'>qemu-system-<replaceable>ARCH</replaceable></command>">
+<!ENTITY usbback                "USB Pass-Through">
+<!ENTITY vagrant                "Vagrant">
+<!ENTITY vagrantfile            "<filename xmlns='http://docbook.org/ns/docbook'>Vagrantfile</filename>">
+<!ENTITY vbox                   "VirtualBox">
+<!ENTITY virtualbox             "&vbox;">
+<!ENTITY virsh                  "<command xmlns='http://docbook.org/ns/docbook'>virsh</command>">
+<!ENTITY vgaback                "VGA Pass-Through">
+<!ENTITY vmguest                "VM Guest">
+<!ENTITY vmhost                 "VM Host Server">
+<!ENTITY vmm                    "Virtual Machine Manager">
+<!ENTITY xcat                   "xCAT">
+<!ENTITY xen                    "Xen">
+<!ENTITY xenreg                 "Xen&reg;">
+<!ENTITY xenstore               "XenStore">
+
 
 
 
 <!-- DAEMONS -->
 
-<!ENTITY chronyd       "<systemitem xmlns='http://docbook.org/ns/docbook' class='daemon'>chronyd</systemitem>">
-<!ENTITY crond         "<systemitem xmlns='http://docbook.org/ns/docbook' class='daemon'>cron</systemitem>">
-<!ENTITY firewalld     "<systemitem xmlns='http://docbook.org/ns/docbook' class='daemon'>firewalld</systemitem>">
-<!ENTITY libvirtd      "<systemitem xmlns='http://docbook.org/ns/docbook' class='daemon'>libvirtd</systemitem>">
-<!ENTITY oprofd        "<systemitem xmlns='http://docbook.org/ns/docbook' class='daemon'>oprofile</systemitem>">
-<!ENTITY systemd       "<systemitem xmlns='http://docbook.org/ns/docbook' class='daemon'>systemd</systemitem>">
+<!ENTITY chronyd                "<systemitem xmlns='http://docbook.org/ns/docbook' class='daemon'>chronyd</systemitem>">
+<!ENTITY crond                  "<systemitem xmlns='http://docbook.org/ns/docbook' class='daemon'>cron</systemitem>">
+<!ENTITY firewalld              "<systemitem xmlns='http://docbook.org/ns/docbook' class='daemon'>firewalld</systemitem>">
+<!ENTITY libvirtd               "<systemitem xmlns='http://docbook.org/ns/docbook' class='daemon'>libvirtd</systemitem>">
+<!ENTITY oprofd                 "<systemitem xmlns='http://docbook.org/ns/docbook' class='daemon'>oprofile</systemitem>">
+<!ENTITY systemd                "<systemitem xmlns='http://docbook.org/ns/docbook' class='daemon'>systemd</systemitem>">
+<!ENTITY systemdcd              "<systemitem xmlns='http://docbook.org/ns/docbook' class='daemon'>systemd-coredump</systemitem>">
+<!ENTITY tuned                  "<systemitem xmlns='http://docbook.org/ns/docbook' class='daemon'>tuned</systemitem>">
 
 
 
 <!-- APPLICATIONS -->
 
-<!ENTITY clamav        "ClamAV">
-<!ENTITY cpufreq       "CPUfreq">
-<!ENTITY gpg           "GPG"> <!-- or GnuGP -->
-<!ENTITY mariadb       "MariaDB">
-<!ENTITY nautilus      "&gnome; Files">
-<!ENTITY oprof         "OProfile">
-<!ENTITY postgresql    "PostgreSQL">
-<!ENTITY powertop      "powerTOP">
-<!ENTITY stap          "SystemTap">
+<!ENTITY clamav                 "ClamAV">
+<!ENTITY cpufreq                "CPUfreq">
+<!ENTITY gpg                    "GPG"> <!-- use GnuPG instead? -->
+<!ENTITY mariadb                "MariaDB">
+<!ENTITY nautilus               "&gnome; Files">
+<!ENTITY oprof                  "OProfile">
+<!ENTITY postgresql             "PostgreSQL">
+<!ENTITY powertop               "powerTOP">
+<!ENTITY stap                   "SystemTap">
 
+
+
+<!-- HARDWARE TECHNOLOGIES -->
+
+<!ENTITY nvme                   "NVMe">
+<!ENTITY nvmeof                 "NVMe over Fabric">
+<!ENTITY fcnvme                 "FC-NVMe">
+<!ENTITY dmmpio                 "DM-Multipathing">
+<!ENTITY mpio                   "multipath I/O">
+
+<!ENTITY hdmi                   "HDMI">
+<!ENTITY hdmireg                "&hdmi;*">
+<!ENTITY mipireg                "MIPI*">
+<!ENTITY mipidsireg             "&mipireg;&nbsp;DSI*">
+<!ENTITY openglreg              "OpenGL*">
+<!ENTITY openglesreg            "&openglreg;&nbsp;ES">
+
+<!ENTITY microsd                "microSD">
+<!ENTITY microsdhc              "microSDHC">
+<!ENTITY bt                     "Bluetooth">
+<!ENTITY btreg                  "Bluetooth*">
+
+<!ENTITY usbflashdrive          "USB flash drive">
+<!ENTITY usbflashdrivecap       "USB Flash Drive">
+
+
+<!-- NETWORK PROTOCOLS -->
+<!ENTITY ptp             "Precision Time Protocol">
+<!ENTITY ntp             "Network Time Protocol">
 
 
 <!-- MISCELLANEOUS -->
 
-<!ENTITY iscsi          "iSCSI">
-<!ENTITY netteam        "Network Teaming">
-<!ENTITY openscap       "OpenSCAP">
-<!ENTITY pcidss         "Payment Card Industry Data Security Standard">
-<!ENTITY pcidssa        "PCI DSS">
+<!ENTITY iscsi                  "iSCSI">
+<!ENTITY netteam                "Network Teaming">
+<!ENTITY openscap               "OpenSCAP">
+<!ENTITY pcidss                 "Payment Card Industry Data Security Standard">
+<!ENTITY pcidssa                "PCI DSS">
+<!ENTITY uefisecboot            "UEFI Secure Boot">
 
 
 
 <!-- BOOK NAMES -->
 
 <!-- SUSE Linux Enterprise -->
-<!ENTITY admin         "<citetitle xmlns='http://docbook.org/ns/docbook'>Administration Guide</citetitle>">
-<!ENTITY auditguide    "<citetitle xmlns='http://docbook.org/ns/docbook'>The Linux Audit Framework</citetitle>">
-<!ENTITY deploy        "<citetitle xmlns='http://docbook.org/ns/docbook'>Deployment Guide</citetitle>">
-<!ENTITY gnomeuser     "<citetitle xmlns='http://docbook.org/ns/docbook'>&gnome; User Guide</citetitle>">
-<!ENTITY haguide       "<citetitle xmlns='http://docbook.org/ns/docbook'>Administration Guide</citetitle>">
-<!ENTITY instquick     "<citetitle xmlns='http://docbook.org/ns/docbook'>Installation Quick Start</citetitle>">
-<!ENTITY reference     "<citetitle xmlns='http://docbook.org/ns/docbook'>Reference</citetitle>">
-<!ENTITY secguide      "<citetitle xmlns='http://docbook.org/ns/docbook'>Security Guide</citetitle>">
-<!ENTITY smtguide      "<citetitle xmlns='http://docbook.org/ns/docbook'>Subscription Management Tool Guide</citetitle>">
-<!ENTITY startup       "<citetitle xmlns='http://docbook.org/ns/docbook'>Start-Up</citetitle>">
-<!ENTITY storage_guide "<citetitle xmlns='http://docbook.org/ns/docbook'>Storage Administration Guide</citetitle>">
-<!ENTITY tuning        "<citetitle xmlns='http://docbook.org/ns/docbook'>System Analysis and Tuning Guide</citetitle>">
-<!ENTITY virtual       "<citetitle xmlns='http://docbook.org/ns/docbook'>Virtualization Guide</citetitle>">
-<!ENTITY upgrade_guide  "<emphasis xmlns='http://docbook.org/ns/docbook'>Upgrade Guide</emphasis>">
+<!ENTITY ayguide                "<citetitle xmlns='http://docbook.org/ns/docbook'>&ay; Guide</citetitle>">
+<!ENTITY deploy                 "<citetitle xmlns='http://docbook.org/ns/docbook'>Deployment Guide</citetitle>">
+<!ENTITY gnomeuser              "<citetitle xmlns='http://docbook.org/ns/docbook'>&gnome; User Guide</citetitle>">
+<!ENTITY instquick              "<citetitle xmlns='http://docbook.org/ns/docbook'>Installation Quick Start</citetitle>">
+<!ENTITY gnomequick             "<citetitle xmlns='http://docbook.org/ns/docbook'>&gnome; Quick Start</citetitle>">
+<!ENTITY modulesquick           "<citetitle xmlns='http://docbook.org/ns/docbook'>Modules and Extensions Quick Start</citetitle>">
+<!ENTITY rpiquick               "<citetitle xmlns='http://docbook.org/ns/docbook'>&rpi; Quick Start</citetitle>">
+<!ENTITY admin                  "<citetitle xmlns='http://docbook.org/ns/docbook'>Administration Guide</citetitle>">
+<!ENTITY reference              "<citetitle xmlns='http://docbook.org/ns/docbook'>Reference</citetitle>">
+<!ENTITY startup                "<citetitle xmlns='http://docbook.org/ns/docbook'>Start-Up</citetitle>">
+<!ENTITY storage_guide          "<citetitle xmlns='http://docbook.org/ns/docbook'>Storage Administration Guide</citetitle>">
+<!ENTITY virtual                "<citetitle xmlns='http://docbook.org/ns/docbook'>Virtualization Guide</citetitle>">
+<!ENTITY auditguide             "<citetitle xmlns='http://docbook.org/ns/docbook'>The Linux Audit Framework</citetitle>">
+<!ENTITY tuning                 "<citetitle xmlns='http://docbook.org/ns/docbook'>System Analysis and Tuning Guide</citetitle>">
+<!ENTITY secguide               "<citetitle xmlns='http://docbook.org/ns/docbook'>Security and Hardening Guide</citetitle>">
+<!ENTITY rmtguide               "<citetitle xmlns='http://docbook.org/ns/docbook'>Repository Management Tool Guide</citetitle>">
+<!ENTITY upgrade_guide          "<citetitle xmlns='http://docbook.org/ns/docbook'>Upgrade Guide</citetitle>">
+
 
 <!-- HA -->
-<!ENTITY haguide       "<citetitle xmlns='http://docbook.org/ns/docbook'>High Availability Guide</citetitle>">
+<!ENTITY haguide                "<citetitle xmlns='http://docbook.org/ns/docbook'>Administration Guide</citetitle>">
+<!ENTITY geoguide               "<citetitle xmlns='http://docbook.org/ns/docbook'>&geo; Clustering Guide</citetitle>">
+<!ENTITY geoquick               "<citetitle xmlns='http://docbook.org/ns/docbook'>&geo; Clustering Quick Start</citetitle>">
+<!ENTITY nfsquick               "<citetitle xmlns='http://docbook.org/ns/docbook'>Highly Available NFS Storage with DRBD and Pacemaker</citetitle>">
+<!ENTITY pcmkremquick           "<citetitle xmlns='http://docbook.org/ns/docbook'>Pacemaker Remote Quick Start</citetitle>">
+
 
 <!-- SUSE Manager -->
-<!ENTITY mgradvtop          "<citetitle xmlns='http://docbook.org/ns/docbook'>Advanced Topics Guide</citetitle>">
-<!ENTITY mgrbestpract       "<citetitle xmlns='http://docbook.org/ns/docbook'>Best Practices Guide</citetitle>">
-<!ENTITY mgrgetstart        "<citetitle xmlns='http://docbook.org/ns/docbook'>Getting Started Guide</citetitle>">
-<!ENTITY mgrrefguide        "<citetitle xmlns='http://docbook.org/ns/docbook'>Reference Guide</citetitle>">
-<!ENTITY mgruserguide       "<citetitle xmlns='http://docbook.org/ns/docbook'>User Guide</citetitle>">
+<!ENTITY mgradvtop              "<citetitle xmlns='http://docbook.org/ns/docbook'>Advanced Topics Guide</citetitle>">
+<!ENTITY mgrbestpract           "<citetitle xmlns='http://docbook.org/ns/docbook'>Best Practices Guide</citetitle>">
+<!ENTITY mgrgetstart            "<citetitle xmlns='http://docbook.org/ns/docbook'>Getting Started Guide</citetitle>">
+<!ENTITY mgrrefguide            "<citetitle xmlns='http://docbook.org/ns/docbook'>Reference Guide</citetitle>">
+<!ENTITY mgruserguide           "<citetitle xmlns='http://docbook.org/ns/docbook'>User Guide</citetitle>">
 
 
 
 <!-- CHARACTER ENTITIES -->
 
-<!ENTITY euro           "&#x20AC;">
-<!ENTITY thrdmrk        "*">
+<!ENTITY euro                   "&#x20AC;">
+<!ENTITY thrdmrk                "*">
 
 
 
 <!-- SYSTEM ENTITIES FOR DOCBOOK 5 -->
 
-<!ENTITY % sgml.features "IGNORE">
-<!ENTITY % xml.features "INCLUDE">
-<!ENTITY % dbcent PUBLIC "-//OASIS//ENTITIES DocBook Character Entities V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/dbcentx.mod">
+<!ENTITY % sgml.features        "IGNORE">
+<!ENTITY % xml.features         "INCLUDE">
+<!ENTITY % dbcent PUBLIC        "-//OASIS//ENTITIES DocBook Character Entities V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/dbcentx.mod">
   %dbcent;
 
 
 <!-- LEGACY COMPATIBILITY ENTITIES -->
 <!-- Do not use in new documentation. -->
 
-<!ENTITY novell        "Novell">
+<!-- Novellian -->
+
+<!ENTITY novell                 "Novell">
+<!ENTITY ncc                    "&scc;">
+
+<!-- Cloud & Storage & Emerging Stuff -->
+
+<!ENTITY cloud                  "&suse; &ostack; Cloud">
+<!ENTITY ses                    "&suse; Enterprise Storage">
+<!ENTITY caasp                  "&suse; CaaS Platform">
+<!ENTITY cap                    "&suse; Cloud Application Platform">
 
 
-<!ENTITY susestudio     "&suse; Studio">
-<!ENTITY studioexpress  "&susestudio; Express">
-<!ENTITY suseonsite     "&susestudio; Onsite">
+<!-- SUSE Enterprise Storage -->
+<!ENTITY ceph                   "Ceph">
+<!ENTITY rook                   "Rook">
 
-<!ENTITY ncc           "&scc;">
 
-<!ENTITY ipseries       "&power;">
-<!ENTITY ppc            "&power;">
+<!-- Studio -->
 
-<!ENTITY smt               "&rmt;">
-<!ENTITY smtool            "&rmtool;">
-<!ENTITY susefirewall      "SuSEfirewall2">
-<!ENTITY susefirewallfiles "SuSEfirewall2">
-<!ENTITY mysql         "&mariadb;">
+<!ENTITY susestudio             "&suse; Studio">
+<!ENTITY studioexpress          "&susestudio; Express">
+<!ENTITY suseonsite             "&susestudio; Onsite">
+
+
+
+<!ENTITY ipseries               "&power;">
+<!ENTITY ppc                    "&power;">
+
+<!ENTITY smt                    "SMT">
+<!ENTITY smtool                 "Subscription Management Tool">
+<!ENTITY susefirewall           "SuSEfirewall2">
+<!ENTITY susefirewallfiles      "SuSEfirewall2">
+<!ENTITY mysql                  "&mariadb;">
 
 <!--SUSE Manager, old guide names -->
-<!ENTITY mgrclientconfguide "<citetitle xmlns='http://docbook.org/ns/docbook'>Client Configuration Guide</citetitle>">
-<!ENTITY mgrinstguide       "<citetitle xmlns='http://docbook.org/ns/docbook'>Installation &amp; Troubleshooting Guide</citetitle>">
-<!ENTITY mgrproxyquick      "<citetitle xmlns='http://docbook.org/ns/docbook'>Proxy Quick Start</citetitle>">
-<!ENTITY mgrquick           "<citetitle xmlns='http://docbook.org/ns/docbook'>Quick Start</citetitle>">
-<!ENTITY mgrrefguide        "<citetitle xmlns='http://docbook.org/ns/docbook'>Reference Guide</citetitle>">
-<!ENTITY mgruserguide       "<citetitle xmlns='http://docbook.org/ns/docbook'>User Guide</citetitle>">
+<!ENTITY mgrclientconfguide     "<citetitle xmlns='http://docbook.org/ns/docbook'>Client Configuration Guide</citetitle>">
+<!ENTITY mgrinstguide           "<citetitle xmlns='http://docbook.org/ns/docbook'>Installation &amp; Troubleshooting Guide</citetitle>">
+<!ENTITY mgrproxyquick          "<citetitle xmlns='http://docbook.org/ns/docbook'>Proxy Quick Start</citetitle>">
+<!ENTITY mgrquick               "<citetitle xmlns='http://docbook.org/ns/docbook'>Quick Start</citetitle>">

--- a/docbook5-book/xml/product-entities-cc.ent
+++ b/docbook5-book/xml/product-entities-cc.ent
@@ -8,7 +8,7 @@
 
 <!-- PROJECT REPOSITORY URL -->
 <!ENTITY repo-url "https://github.com/SUSE/doc-[PRODUCT]">
-<!ENTITY repo-readme "&repo-url;/blob/master/README.adoc">
+<!ENTITY repo-readme "&repo-url;/blob/main/README.adoc">
 
 <!-- DOCUMENTATION.SUSE.COM PRODUCT URL -->
 <!ENTITY doc-url "&dsc;/[PRODUCT]/[VERSION]">

--- a/docbook5-book/xml/product-entities-gfdl.ent
+++ b/docbook5-book/xml/product-entities-gfdl.ent
@@ -2,22 +2,22 @@
 <!-- This file can be edited downstream. -->
 
 <!-- PRODUCT NAME AND VERSIONS -->
-<!ENTITY productname   "PRODUCT">
-<!ENTITY productnumber "X.Y">
+<!ENTITY productname            "PRODUCT">
+<!ENTITY productnumber          "X.Y">
 
 
 <!-- PROJECT REPOSITORY URL -->
-<!ENTITY repo-url "https://github.com/SUSE/doc-[PRODUCT]">
-<!ENTITY repo-readme "&repo-url;/blob/master/README.adoc">
+<!ENTITY repo-url               "https://github.com/SUSE/doc-[PRODUCT]">
+<!ENTITY repo-readme            "&repo-url;/blob/main/README.adoc">
 
 <!-- DOCUMENTATION.SUSE.COM PRODUCT URL -->
-<!ENTITY doc-url "&dsc;/[PRODUCT]/[VERSION]">
+<!ENTITY doc-url                "&dsc;/[PRODUCT]/[VERSION]">
 
 <!-- RELEASE NOTES URL -->
-<!ENTITY rn-url "&sc-rn;/x86_64/[PRODUCT]/[VERSION]">
+<!ENTITY rn-url                 "&sc-rn;/x86_64/[PRODUCT]/[VERSION]">
 
 
 <!-- START YEAR OF COPYRIGHT -->
-<!ENTITY copyrightstart  "20XX">
+<!ENTITY copyrightstart         "20XX">
 <!-- COPYRIGHT HOLDER(S) -->
-<!ENTITY copyrightholder "SUSE LLC">
+<!ENTITY copyrightholder        "SUSE LLC">

--- a/docbook5-entities-only.MANIFEST
+++ b/docbook5-entities-only.MANIFEST
@@ -1,0 +1,9 @@
+v0.2
+--
+always: ../.gitignore -> .gitignore
+always: ../.editorconfig -> .editorconfig
+
+initial(license-gfdl): ../docbook5-book/xml/product-entities-gfdl.ent -> xml/product-entities.ent
+initial(license-cc): ../docbook5-book/xml/product-entities-cc.ent -> xml/product-entities.ent
+always: ../docbook5-book/xml/generic-entities.ent -> xml/generic-entities.ent
+always: ../docbook5-book/xml/network-entities.ent -> xml/network-entities.ent


### PR DESCRIPTION
This hopefully makes it easier for existing projects to use at least some of the Doc Kit updatery.

You'd only have to replace the entity files. The intro files are not included here but you can always switch to the full DocBook 5 book kit.