### PR TITLE
db-5 book: add <dm:editurl> to MAIN

### DIFF
--- a/docbook5-book/xml/MAIN.book-example-cc.xml
+++ b/docbook5-book/xml/MAIN.book-example-cc.xml
@@ -34,6 +34,7 @@
      <dm:product>Product Name</dm:product>
      <dm:assignee>assignee@suse.com</dm:assignee>
     </dm:bugtracker>
+    <dm:editurl>GitHub URL (path to xml directory)</dm:editurl>
     <dm:translation>yes</dm:translation>
    </dm:docmanager>
  </info>

--- a/docbook5-book/xml/MAIN.book-example-gfdl.xml
+++ b/docbook5-book/xml/MAIN.book-example-gfdl.xml
@@ -34,6 +34,7 @@
      <dm:product>Product Name</dm:product>
      <dm:assignee>assignee@suse.com</dm:assignee>
     </dm:bugtracker>
+    <dm:editurl>GitHub URL (path to xml directory)</dm:editurl>
     <dm:translation>yes</dm:translation>
    </dm:docmanager>
  </info>


### PR DESCRIPTION
To make the 'Edit Source' links available in our HTML builds, we need `<dm:editurl>` in the MAIn files, e.g.
` <dm:editurl>https://github.com/SUSE/doc-sle/edit/main/xml/</dm:editurl>`

Adding a placeholder.