### PR TITLE
Update the spelling of 'user space live patching'

### DIFF
--- a/docbook5-book/xml/generic-entities.ent
+++ b/docbook5-book/xml/generic-entities.ent
@@ -276,7 +276,7 @@ use &deng;! -->
 <!ENTITY kg                     "kGraft">
 <!ENTITY klp                    "Kernel Live Patching">
 <!ENTITY klpa                   "KLP">
-<!ENTITY ulp                    "userspace live patching">
+<!ENTITY ulp                    "user space live patching">
 <!ENTITY ulpa                   "ULP">
 <!ENTITY kiwi                   "KIWI">
 <!ENTITY kprobes                "Kprobes">


### PR DESCRIPTION
The expansion for the &ulp; entity was updated from 'userspace live patching' to 'user space live patching'. 