### PR TITLE
Add entity for HA installation quickstart

### DIFF
--- a/docbook5-book/xml/generic-entities.ent
+++ b/docbook5-book/xml/generic-entities.ent
@@ -478,6 +478,7 @@ use &deng;! -->
 
 <!-- HA -->
 <!ENTITY haguide                "<citetitle xmlns='http://docbook.org/ns/docbook'>Administration Guide</citetitle>">
+<!ENTITY haquick                "<citetitle xmlns='http://docbook.org/ns/docbook'>Installation and Setup Quick Start</citetitle>">
 <!ENTITY geoguide               "<citetitle xmlns='http://docbook.org/ns/docbook'>&geo; Clustering Guide</citetitle>">
 <!ENTITY geoquick               "<citetitle xmlns='http://docbook.org/ns/docbook'>&geo; Clustering Quick Start</citetitle>">
 <!ENTITY nfsquick               "<citetitle xmlns='http://docbook.org/ns/docbook'>Highly Available NFS Storage with DRBD and Pacemaker</citetitle>">


### PR DESCRIPTION
In the SLE HA repo this guide used the same entity name (instquick) as the SLE installation quickstart. Unfortunately the two guides do not have the same title (that would have been very convenient).  