### PR TITLE
Set translation flags correctly

### DIFF
--- a/docbook5-book/xml/common_license_gfdl1.2.xml
+++ b/docbook5-book/xml/common_license_gfdl1.2.xml
@@ -16,6 +16,12 @@
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>GNU Free Documentation License</title>
+ <info>
+  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager"></dm:docmanager>
+  <dm:bugtracker></dm:bugtracker>
+  <dm:translation>no</dm:translation>
+ </info>
+
 
  <para>
   Copyright (C) 2000, 2001, 2002 Free Software Foundation, Inc. 51 Franklin St,


### PR DESCRIPTION
As discussed in the meeting this morning, I have checked all XML files within `docbook5-book` to make sure the translation flags are set correctly. The only file which was missing a `<dm: translation>` element was `common_license_gfdl1.2.xml` (which is an XInclude), but I have added an `info ` element with this tag there as well and set it to `no`, as we usually do not translate the GFDL text.

With this PR, all template files should now have the correct translation flags set.

In this wake, I have discovered that two more files are outdated (contentwise) meanwhile, but I will create a separate PR for those. 