### PR TITLE
Introduce &productnameshort; entity

### DIFF
--- a/docbook5-book/xml/MAIN.book-example-cc.xml
+++ b/docbook5-book/xml/MAIN.book-example-cc.xml
@@ -20,6 +20,7 @@
    <title>Example guide</title>
    <productname>&productname;</productname>
    <productnumber>&productnumber;</productnumber>
+   <productname role="abbrev">&productnameshort;</productname>
    <date><?dbtimestamp format="B d, Y"?></date>
    <xi:include href="common_copyright_cc.xml"/>
    <abstract>

--- a/docbook5-book/xml/MAIN.book-example-gfdl.xml
+++ b/docbook5-book/xml/MAIN.book-example-gfdl.xml
@@ -20,6 +20,7 @@
    <title>Example guide</title>
    <productname>&productname;</productname>
    <productnumber>&productnumber;</productnumber>
+   <productname role="abbrev">&productnameshort;</productname>
    <date><?dbtimestamp format="B d, Y"?></date>
    <xi:include href="common_copyright_gfdl.xml"/>
    <abstract>

--- a/docbook5-book/xml/product-entities-cc.ent
+++ b/docbook5-book/xml/product-entities-cc.ent
@@ -3,6 +3,7 @@
 
 <!-- PRODUCT NAME AND VERSIONS -->
 <!ENTITY productname   "PRODUCT">
+<!ENTITY productnameshort "ACRONYM">
 <!ENTITY productnumber "X.Y">
 
 

--- a/docbook5-book/xml/product-entities-gfdl.ent
+++ b/docbook5-book/xml/product-entities-gfdl.ent
@@ -3,6 +3,7 @@
 
 <!-- PRODUCT NAME AND VERSIONS -->
 <!ENTITY productname            "PRODUCT">
+<!ENTITY productnameshort       "ACRONYM">
 <!ENTITY productnumber          "X.Y">
 
 


### PR DESCRIPTION
Fixes DOCTEAM-828 which was discussed in SLE Writers Call on 2022-11-21. It contains additions of the entity `&productnameshort;` and a XML structure that uses it.

I'm wondering if we should amend `adoc/attributes-product.adoc` too. :thinking: Something like this:

```adoc
:product: ProductName
:productnameshort: Acronym
:producta: PN
```