### PR TITLE
preface: add missing <dm:translation/>

### DIFF
--- a/docbook5-book/xml/preface_example.xml
+++ b/docbook5-book/xml/preface_example.xml
@@ -16,7 +16,11 @@
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Preface</title>
-
+ <info>
+  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+   <dm:translation>yes</dm:translation>
+  </dm:docmanager>
+ </info>
  <xi:include href="common_intro_available_doc.xml"/>
  <xi:include href="common_intro_feedback.xml"/>
  <xi:include href="common_intro_convention.xml"/>


### PR DESCRIPTION
I noticed that the preface template file is missing the translation information. Added it.