### PR TITLE
common_intro_conventions: bring entity in snyc with profiling

### DIFF
--- a/docbook5-book/xml/common_intro_convention.xml
+++ b/docbook5-book/xml/common_intro_convention.xml
@@ -72,7 +72,7 @@
   </listitem>
   <listitem os="sles;slemicro">
    <para arch="x86_64">
-    This paragraph is only relevant for the &amd64;/&intel64; architectures. The
+    This paragraph is only relevant for the &x86-64; architectures. The
     arrows mark the beginning and the end of the text block.
    </para>
    <para arch="zseries;power">


### PR DESCRIPTION
I had changed this to what we used in doc-sle with https://github.com/openSUSE/doc-kit/commit/07dda2bafc2fa1fc7906b441098a05abf9261064 but I think Christoph's suggestion from our internal chat is correct: it should match the profiling of the paragraph. 

Currently, `&86-64;` resolves to `&amd64;/&intel64;` anyway. 