### PR TITLE
MANIFEST: always update common_intro_available_doc.xml

### DIFF
--- a/docbook5-book.MANIFEST
+++ b/docbook5-book.MANIFEST
@@ -19,7 +19,7 @@ initial: xml/example_doc_updates.xml
 
 initial: images/src/png/example.png
 
-initial: xml/common_intro_available_doc.xml
+always: xml/common_intro_available_doc.xml
 always: xml/common_intro_support.xml
 always: xml/common_intro_convention.xml
 always: xml/common_intro_feedback.xml


### PR DESCRIPTION
Adjust docbook5-book.MANIFEST: `common_intro_available_doc.xml` should always be updated, not just initially (as agreed in our internal channel on 2023-09-12).

Related issues: https://github.com/openSUSE/doc-kit/issues/63