### PR TITLE
generic: add DB4 entities

### DIFF
--- a/docbook5-book/xml/generic-entities.ent
+++ b/docbook5-book/xml/generic-entities.ent
@@ -549,14 +549,14 @@ use &deng;! -->
 
 <!-- DOCBOOK 4 ENTITITES -->
 
-<!ENTITY dash             "&#x02010;" >
-<!ENTITY ndash            "&#x02013;" >
-<!ENTITY trade            "&#x02122;" >
-<!ENTITY copy             "&#x000A9;" >
-<!ENTITY sol              "&#x0002F;" >
-<!ENTITY rdquo            "&#x0201D;" >
-<!ENTITY ldquo            "&#x0201C;" >
-<!ENTITY nbsp             "&#x000A0;" >
+<!ENTITY dash             "&#x02010;" ><!--HYPHEN -->
+<!ENTITY ndash            "&#x02013;" ><!--EN DASH -->
+<!ENTITY trade            "&#x02122;" ><!--TRADE MARK SIGN --
+<!ENTITY copy             "&#x000A9;" ><!--COPYRIGHT SIGN -->
+<!ENTITY sol              "&#x0002F;" ><!--SOLIDUS -->
+<!ENTITY rdquo            "&#x0201D;" ><!--RIGHT DOUBLE QUOTATION MARK -->
+<!ENTITY ldquo            "&#x0201C;" ><!--LEFT DOUBLE QUOTATION MARK -->
+<!ENTITY nbsp             "&#x000A0;" ><!--NO-BREAK SPACE -->
 
 <!-- LEGACY COMPATIBILITY ENTITIES -->
 <!-- Do not use in new documentation. -->

--- a/docbook5-book/xml/generic-entities.ent
+++ b/docbook5-book/xml/generic-entities.ent
@@ -547,6 +547,16 @@ use &deng;! -->
 <!ENTITY % dbcent PUBLIC        "-//OASIS//ENTITIES DocBook Character Entities V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/dbcentx.mod">
   %dbcent;
 
+<!-- DOCBOOK 4 ENTITITES -->
+
+<!ENTITY dash             "&#x02010;" >
+<!ENTITY ndash            "&#x02013;" >
+<!ENTITY trade            "&#x02122;" >
+<!ENTITY copy             "&#x000A9;" >
+<!ENTITY sol              "&#x0002F;" >
+<!ENTITY rdquo            "&#x0201D;" >
+<!ENTITY ldquo            "&#x0201C;" >
+<!ENTITY nbsp             "&#x000A0;" >
 
 <!-- LEGACY COMPATIBILITY ENTITIES -->
 <!-- Do not use in new documentation. -->


### PR DESCRIPTION
Related to the discussion in https://github.com/openSUSE/doc-kit/pull/71: Within our texts, we still use some general entities provided by DocBook4, like:

- nbsp
- dash 
- ndash
- trade
- copy
- sol
- rdquo
- ldquo

Moving them to `generic-entities.ent` removes our need to keep the DB4 package for legacy reasons (as we have moved on to DB5 meanwhile). 