### PR TITLE
Remove DocBook 4 dependency (entities)

### DIFF
--- a/docbook5-book/xml/generic-entities.ent
+++ b/docbook5-book/xml/generic-entities.ent
@@ -539,14 +539,6 @@ use &deng;! -->
 <!ENTITY thrdmrk                "*">
 
 
-
-<!-- SYSTEM ENTITIES FOR DOCBOOK 5 -->
-
-<!ENTITY % sgml.features        "IGNORE">
-<!ENTITY % xml.features         "INCLUDE">
-<!ENTITY % dbcent PUBLIC        "-//OASIS//ENTITIES DocBook Character Entities V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/dbcentx.mod">
-  %dbcent;
-
 <!-- DOCBOOK 4 ENTITITES -->
 
 <!ENTITY dash             "&#x02010;" ><!--HYPHEN -->


### PR DESCRIPTION
:information_source: Something to be discussed next week.

As our docs are written in DocBook 5 now, we would like to reduce the dependency for pre-defined DocBook 4 entities. This line contains this reference in the `generic-entities.ent` file:

    "-//OASIS//ENTITIES DocBook Character Entities V4.5//EN"
    "http://www.oasis-open.org/docbook/xml/4.5/dbcentx.mod"

We already have defined the most used entities from doc-sle and integrated them in PR #72. The reference is not needed anymore.

---

When we migrated from DocBook 4 to DocBook 5, we needed these entities. However, I think, this is no longer the case:


* Although sometimes convenient, the DocBook 4 entities are kind of a "relict" from the DTD era. The DTD defined and used them and so they were automatically available in every DocBook 4 document. DocBook 5 doesn't define nor use them anymore. It's even technically not possible to include them in a RELAX NG schema.
* We don't necessarily need these entities. Whenever writers want to use a specific glyph, they can 
  * add the Unicode code as a character entity (for example, &#x02122; for the trademark symbol) or
  * enter the glyph directly. That should be supported by the editor or keyboard and the preferred method in DocBook 5.
* Out of 995 entity definitions, we have only used a tiny fraction (if I counted right, it's only 9).
* If writers still want to use them, the most useful entities are already defined in main. Thanks to Tomas!
* Whenever we have the feeling that we missing an entity, we can add it to doc-kit. However, I'd say, we should keep this list short.