### PR TITLE
generic-ent: add entities from doc-modular

### DIFF
--- a/entities/generic-entities.ent
+++ b/entities/generic-entities.ent
@@ -57,6 +57,7 @@
 <!-- SUSE PRODUCTS -->
 
 <!ENTITY sliberty               "&suse; Liberty Linux">
+<!ENTITY neuvector              "NeuVector">
 
 <!-- SLE -->
 <!ENTITY jeos                   "JeOS"><!-- Just enough OS -->
@@ -78,11 +79,13 @@
 <!ENTITY s4s                    "&sles4sap;">
 <!ENTITY slem                   "&sle; Micro">
 <!ENTITY bci-product            "&slea; Base Container Images">
-<!ENTITY dinstaller             "Agama">
+
 
 <!-- ALP -->
 <!ENTITY alp                    "Adaptable Linux Platform">
 <!ENTITY alpshort               "ALP">
+<!ENTITY alp-dolomite           "ALP&nbsp;Dolomite">
+
 
 <!-- SLE HA -->
 
@@ -269,6 +272,9 @@ use &deng;! -->
 <!ENTITY ad                     "Active Directory">
 <!ENTITY ada                    "AD">
 <!ENTITY aide                   "AIDE">
+<!ENTITY alp-installer          "Agama">
+<!ENTITY dinstaller             "Agama">
+<!ENTITY ansible                "Ansible">
 <!ENTITY ay                     "AutoYaST">
 <!ENTITY bcache                 "<systemitem xmlns='http://docbook.org/ns/docbook' class='resource'>bcache</systemitem>">
 <!ENTITY chrony                 "<systemitem xmlns='http://docbook.org/ns/docbook' class='resource'>chrony</systemitem>">
@@ -280,12 +286,14 @@ use &deng;! -->
 <!ENTITY grub                   "GRUB&nbsp;2">
 <!ENTITY grub-efi               "GRUB&nbsp;2 for EFI">
 <!ENTITY kdump                  "Kdump">
+<!ENTITY kea                    "Kea">
 <!ENTITY kexec                  "Kexec">
 <!ENTITY kg                     "kGraft">
 <!ENTITY klp                    "Kernel Live Patching">
 <!ENTITY klpa                   "KLP">
 <!ENTITY ulp                    "user space live patching">
 <!ENTITY ulpa                   "ULP">
+<!ENTITY keylime                "Keylime">
 <!ENTITY kiwi                   "KIWI&nbsp;NG">
 <!ENTITY kprobes                "Kprobes">
 <!ENTITY krb                    "Kerberos">
@@ -305,10 +313,12 @@ use &deng;! -->
 <!ENTITY selnx                  "SELinux">
 <!ENTITY smaster                "&salt; Master">
 <!ENTITY sminion                "&salt; Minion">
+<!ENTITY snapper                "Snapper">
 <!ENTITY sudo                   "<command xmlns='http://docbook.org/ns/docbook'>sudo</command>">
 <!ENTITY suseconnect            "SUSEConnect">
-<!ENTITY tr-up                   "<command xmlns='http://docbook.org/ns/docbook'>transactional-update</command>">
-<!ENTITY tr-up-shell             "<command xmlns='http://docbook.org/ns/docbook'>transactional-update shell</command>">
+<!ENTITY tr-up                  "<command xmlns='http://docbook.org/ns/docbook'>transactional-update</command>">
+<!ENTITY tr-up-shell            "<command xmlns='http://docbook.org/ns/docbook'>transactional-update shell</command>">
+<!ENTITY tr-up-run              "<command xmlns='http://docbook.org/ns/docbook'>transactional-update run</command>">
 <!ENTITY xgeneric               "X Window System">
 <!ENTITY xvendor                "X.Org">
 <!ENTITY yast                   "YaST">
@@ -316,6 +326,10 @@ use &deng;! -->
 <!ENTITY ycc_runlevel           "Services Manager">
 <!ENTITY yelp                   "Help">
 
+
+<!-- ALP -->
+<!ENTITY fuelignition-dld-site   "https://ignite.opensuse.org">
+<!ENTITY virt-scenario           "<command xmlns='http://docbook.org/ns/docbook'>virt-scenario</command>">
 
 
 <!-- HA -->
@@ -362,11 +376,14 @@ use &deng;! -->
 
 <!-- VIRTUALIZATION -->
 
+<!ENTITY amdsev                 "AMD SEV">
 <!ENTITY dom0                   "Dom0">
 <!ENTITY esx                    "&vmware; ESX">
 <!ENTITY gpuback                "GPU Pass-Through">
 <!ENTITY hyperv                 "&ms; Hyper-V">
 <!ENTITY kvm                    "KVM">
+<!ENTITY kvmserver              "&kvm; Server">
+<!ENTITY kvmclient              "&kvm; Client">
 <!ENTITY libvirt                "<systemitem xmlns='http://docbook.org/ns/docbook' class='library'>libvirt</systemitem>">
 <!ENTITY pciback                "PCI Pass-Through">
 <!ENTITY qemu                   "QEMU">
@@ -425,6 +442,7 @@ use &deng;! -->
 
 
 
+
 <!-- HARDWARE TECHNOLOGIES -->
 
 <!ENTITY nvme                   "NVMe">
@@ -448,6 +466,8 @@ use &deng;! -->
 
 <!ENTITY usbflashdrive          "USB flash drive">
 <!ENTITY usbflashdrivecap       "USB Flash Drive">
+
+<!ENTITY infiniband              "InfiniBand">
 
 
 <!-- NETWORK PROTOCOLS -->
@@ -476,6 +496,8 @@ use &deng;! -->
 
 <!ENTITY iscsi                  "iSCSI">
 <!ENTITY netteam                "Network Teaming">
+<!ENTITY opensm                 "opensm">
+<!ENTITY subnetmanager          "Subnet Manager">
 
 
 

--- a/entities/generic-entities.ent
+++ b/entities/generic-entities.ent
@@ -84,7 +84,7 @@
 <!-- ALP -->
 <!ENTITY alp                    "Adaptable Linux Platform">
 <!ENTITY alpshort               "ALP">
-<!ENTITY alp-dolomite           "ALP&nbsp;Dolomite">
+<!ENTITY alp-dolomite           "&alpshort;&nbsp;Dolomite">
 
 
 <!-- SLE HA -->
@@ -273,7 +273,7 @@ use &deng;! -->
 <!ENTITY ada                    "AD">
 <!ENTITY aide                   "AIDE">
 <!ENTITY alp-installer          "Agama">
-<!ENTITY dinstaller             "Agama">
+<!ENTITY dinstaller             "&alp-installer;">
 <!ENTITY ansible                "Ansible">
 <!ENTITY ay                     "AutoYaST">
 <!ENTITY bcache                 "<systemitem xmlns='http://docbook.org/ns/docbook' class='resource'>bcache</systemitem>">
@@ -556,7 +556,7 @@ use &deng;! -->
 
 
 <!-- CHARACTER ENTITIES -->
-
+<!ENTITY checkmark              "&#x2714;">
 <!ENTITY euro                   "&#x20AC;">
 <!ENTITY thrdmrk                "*">
 


### PR DESCRIPTION
Some of the entities covered in the `product-entities.ent` file in the `doc-modular` repo need to be moved to `generic-entities.ent`:


```
<!-- move to generic-entites.ent later on -->
<!ENTITY kvmserver               "&kvm; Server">
<!ENTITY kvmclient               "&kvm; Client">
<!ENTITY neuvector               "NeuVector">
 [...]
<!ENTITY alp-installer           "Agama">
<!ENTITY keylime                 "Keylime">
<!ENTITY snapper                 "Snapper">
<!ENTITY opensm                  "opensm">
<!ENTITY infiniband              "InfiniBand">
<!ENTITY subnetmanager           "Subnet Manager">
```