### PR TITLE
docbook5-book: enhance preface 

### DIFF
--- a/docbook5-book/xml/common_intro_available_doc.xml
+++ b/docbook5-book/xml/common_intro_available_doc.xml
@@ -40,6 +40,17 @@
     </note>
    </listitem>
   </varlistentry>
+  <varlistentry>
+   <term>&suse; Knowledgebase</term>
+   <!--based on 'Support Resources' listed at https://www.suse.com/support/kb/-->
+   <listitem>
+    <para>
+     If you have run into an issue, also check out the Technical Information
+     Documents (TIDs) that are available online at <link xlink:href="https://www.suse.com/support/kb/"/>.
+     Search the &suse; Knowledgebase for known solutions driven by customer need.
+     </para>
+   </listitem>
+  </varlistentry>
   <varlistentry condition="suse-product">
    <term>Release notes</term>
    <listitem>

--- a/docbook5-book/xml/common_intro_convention.xml
+++ b/docbook5-book/xml/common_intro_convention.xml
@@ -104,8 +104,8 @@
   </listitem>
   <listitem>
    <para>
-    Commands can be split into two or multiple lines by a <literal>\</literal> at
-    the end of a line. The character <literal>\</literal> informs the shell that
+    Commands can be split into two or multiple lines by a backslash character
+    (<literal>\</literal>) at the end of a line. The backslash informs the shell that
     the command invocation will continue after the line's end:
    </para>
    <screen>&prompt.user;<command>echo</command> a b \

--- a/docbook5-book/xml/common_intro_convention.xml
+++ b/docbook5-book/xml/common_intro_convention.xml
@@ -112,6 +112,14 @@
 --language=pt_BR</screen>
   </listitem>
   <listitem>
+    <para>
+     A code block that shows both a command (preceded by a prompt)
+     and the respective output returned by the shell:
+    </para>
+    <screen>&prompt.user;<command>command</command>
+output</screen>
+  </listitem>
+  <listitem>
    <para>
     Notices
    </para>

--- a/docbook5-book/xml/common_intro_convention.xml
+++ b/docbook5-book/xml/common_intro_convention.xml
@@ -104,6 +104,15 @@
   </listitem>
   <listitem>
    <para>
+    Long commands are split into two or multiple lines by adding an <literal>\</literal> at
+    the end of a line. The character <literal>\</literal> informs the shell that
+    the command invocation will continue after the end of the line.
+   </para>
+   <screen>&prompt.sudo;<command>systemd-run</command> --on-active="2hours" /usr/local/bin/helloworld.sh \
+--language=pt_BR</screen>
+  </listitem>
+  <listitem>
+   <para>
     Notices
    </para>
    <warning>

--- a/docbook5-book/xml/common_intro_convention.xml
+++ b/docbook5-book/xml/common_intro_convention.xml
@@ -89,31 +89,31 @@
   </listitem>
   <listitem>
    <para>
-    Commands that must be run with &rootuser; privileges. Often you can also
+    Commands that must be run with &rootuser; privileges. You can also
     prefix these commands with the <command>sudo</command> command to run them
-    as non-privileged user.
+    as a non-privileged user:
    </para>
    <screen>&prompt.root;<command>command</command>
 &prompt.sudo;<command>command</command></screen>
   </listitem>
   <listitem>
    <para>
-    Commands that can be run by non-privileged users.
+    Commands that can be run by non-privileged users:
    </para>
 <screen>&prompt.user;<command>command</command></screen>
   </listitem>
   <listitem>
    <para>
-    Long commands are split into two or multiple lines by adding an <literal>\</literal> at
+    Commands can be split into two or multiple lines by a <literal>\</literal> at
     the end of a line. The character <literal>\</literal> informs the shell that
-    the command invocation will continue after the end of the line.
+    the command invocation will continue after the line's end:
    </para>
-   <screen>&prompt.sudo;<command>systemd-run</command> --on-active="2hours" /usr/local/bin/helloworld.sh \
---language=pt_BR</screen>
+   <screen>&prompt.user;<command>echo</command> a b \
+c d</screen>
   </listitem>
   <listitem>
     <para>
-     A code block that shows both a command (preceded by a prompt)
+     A code block that shows both the command (preceded by a prompt)
      and the respective output returned by the shell:
     </para>
     <screen>&prompt.user;<command>command</command>

--- a/docbook5-book/xml/common_intro_feedback.xml
+++ b/docbook5-book/xml/common_intro_feedback.xml
@@ -82,8 +82,7 @@
     </note>
     <para>
      For more information about the documentation environment used for this
-     documentation, see the repository's README at
-     <link xlink:href="&repo-url;"/>.
+     documentation, see the repository's README.
     </para>
    </listitem>
   </varlistentry>


### PR DESCRIPTION
Fixes several issues with the common_intro* files in the preface of our books.

- jsc#DOCTEAM-141: Knowledgebase base (TIDs)
- jsc#DOCTEAM-879: enhance typography section in prefaces (doc-kit)
- remove an entity in `common_intro_feedback.xml` that prevented the example PDF from building (just based on the boilerplate files being delivered by doc-kit). 
 
The latter will also help to fix https://github.com/SUSE/doc-styleguide/issues/135 as per suggestion in https://github.com/SUSE/doc-styleguide/issues/135#issuecomment-1833649882. 