### PR TITLE
fix links: http -> https

### DIFF
--- a/docbook5-book/xml/common_copyright_cc.xml
+++ b/docbook5-book/xml/common_copyright_cc.xml
@@ -30,7 +30,7 @@
  </para>
  <para>
   For &suse; trademarks, see
-  <link xlink:href="http://www.suse.com/company/legal/"/>. All
+  <link xlink:href="https://www.suse.com/company/legal/"/>. All
   third-party trademarks are the property of their respective owners. Trademark
   symbols (&reg;, &trade; etc.) denote trademarks of &suse; and its affiliates.
   Asterisks (&thrdmrk;) denote third-party trademarks.

--- a/docbook5-book/xml/common_copyright_gfdl.xml
+++ b/docbook5-book/xml/common_copyright_gfdl.xml
@@ -33,7 +33,7 @@
  </para>
  <para>
   For &suse; trademarks, see
-  <link xlink:href="http://www.suse.com/company/legal/"/>. All
+  <link xlink:href="https://www.suse.com/company/legal/"/>. All
   third-party trademarks are the property of their respective owners. Trademark
   symbols (&reg;, &trade; etc.) denote trademarks of &suse; and its affiliates.
   Asterisks (&thrdmrk;) denote third-party trademarks.

--- a/docbook5-book/xml/common_intro_feedback.xml
+++ b/docbook5-book/xml/common_intro_feedback.xml
@@ -31,7 +31,7 @@
    <listitem>
     <para>
      For services and support options available for your product, see
-     <link xlink:href="http://www.suse.com/support/"/>.
+     <link xlink:href="https://www.suse.com/support/"/>.
     </para>
     <para>
      To open a service request, you need a &suse; subscription registered at

--- a/docbook5-book/xml/common_license_gfdl1.2.xml
+++ b/docbook5-book/xml/common_license_gfdl1.2.xml
@@ -504,7 +504,7 @@
   Free Documentation License from time to time. Such new versions will be
   similar in spirit to the present version, but may differ in detail to address
   new problems or concerns. See
-  <link xlink:href="http://www.gnu.org/copyleft/">http://www.gnu.org/copyleft/</link>.
+  <link xlink:href="https://www.gnu.org/copyleft/">https://www.gnu.org/copyleft/</link>.
  </para>
 
  <para>

--- a/smart-doc/common/legal.xml
+++ b/smart-doc/common/legal.xml
@@ -22,7 +22,7 @@
     in the section entitled <quote>GNU Free Documentation License</quote>.
   </para>
   <para>
-    For SUSE trademarks, see <link xlink:href="http://www.suse.com/company/legal/"/>. All other
+    For SUSE trademarks, see <link xlink:href="https://www.suse.com/company/legal/"/>. All other
     third-party trademarks are the property of their respective owners. Trademark symbols (®, ™
     etc.) denote trademarks of SUSE and its affiliates. Asterisks (*) denote third-party
     trademarks.

--- a/smart-doc/common/license_gfdl1.2.xml
+++ b/smart-doc/common/license_gfdl1.2.xml
@@ -499,7 +499,7 @@
   Free Documentation License from time to time. Such new versions will be
   similar in spirit to the present version, but may differ in detail to address
   new problems or concerns. See
-  <link xlink:href="http://www.gnu.org/copyleft/">http://www.gnu.org/copyleft/</link>.
+  <link xlink:href="https://www.gnu.org/copyleft/">https://www.gnu.org/copyleft/</link>.
  </para>
 
  <para>


### PR DESCRIPTION
### PR creator: Description

Our tools reported some broken links. Updating the links to use https where available. 
Applying the changes from doc-sle/PR#1635 to the boilerplate files managed by doc-kit.

### PR creator: Are there any relevant issues/feature requests?

* related PR for doc-sle: https://github.com/SUSE/doc-sle/pull/1635



