### PR TITLE
Remove content from <link> and make it empty

### DIFF
--- a/docbook5-book/xml/common_license_gfdl1.2.xml
+++ b/docbook5-book/xml/common_license_gfdl1.2.xml
@@ -504,7 +504,7 @@
   Free Documentation License from time to time. Such new versions will be
   similar in spirit to the present version, but may differ in detail to address
   new problems or concerns. See
-  <link xlink:href="https://www.gnu.org/copyleft/">https://www.gnu.org/copyleft/</link>.
+  <link xlink:href="https://www.gnu.org/copyleft/"/>.
  </para>
 
  <para>

--- a/smart-doc/common/license_gfdl1.2.xml
+++ b/smart-doc/common/license_gfdl1.2.xml
@@ -499,7 +499,7 @@
   Free Documentation License from time to time. Such new versions will be
   similar in spirit to the present version, but may differ in detail to address
   new problems or concerns. See
-  <link xlink:href="https://www.gnu.org/copyleft/">https://www.gnu.org/copyleft/</link>.
+  <link xlink:href="https://www.gnu.org/copyleft/"/>.
  </para>
 
  <para>


### PR DESCRIPTION

### PR creator: Description

If the content of a `<link>` tag and its `xlink:href` attribute content is the same, it's better to remove the content. It doesn't bring any benefit and is harder to read and more error-prone.

=> Make `<link/>` an empty link.


### PR creator: Are there any relevant issues/feature requests?

* n/a
