### PR TITLE
Entities: Remove composite URLs with entities

### DIFF
--- a/entities/generic-entities.ent
+++ b/entities/generic-entities.ent
@@ -209,25 +209,12 @@ use &deng;! -->
 
 
 <!-- URLS -->
+<!-- use stand-alone only, not as part of URLs, see Style Guide-->
 
 <!ENTITY dsc                    "https://documentation.suse.com">
-<!ENTITY dsc-sles               "&dsc;/sles">
-<!ENTITY dsc-sled               "&dsc;/sled">
-<!ENTITY dsc-ha                 "&dsc;/sle-ha">
-<!ENTITY dsc-sap                "&dsc;/sles-sap">
-<!ENTITY dsc-ses                "&dsc;/ses">
-<!ENTITY dsc-suma               "&dsc;/suma">
-<!ENTITY dsc-caasp              "&dsc;/suse-caasp">
-<!ENTITY dsc-cap                "&dsc;/suse-cap">
-<!ENTITY dsc-soc                "&dsc;/soc">
-
-
 <!ENTITY beta-www               "https://susedoc.github.io">
-
 <!ENTITY doo                    "https://doc.opensuse.org">
-
 <!ENTITY sc-rn                  "https://www.suse.com/releasenotes">
-
 <!ENTITY sccurl                 "https://scc.suse.com/">
 
 <!-- HARDWARE ARCHITECTURES AND PLATFORMS -->


### PR DESCRIPTION
### PR creator: Description

According to our Style Guide, the use of entities for URLs is discouraged. But we still offer them in several entity declaration files.  

For now, I removed the ones for composite URLs in generic-entities.ent and added a comment for the remaining ones.  

My question is:

- Should we remove all URL entities? 
- Or should we keep the general ones in ll.214-218? (for stand-alone use this would be OK IMHO)

 
### PR creator: Are there any relevant issues/feature requests?

Style Guide, see https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-link-to-susecom:

"Make sure to use complete URLs instead of entities for an easy copy and paste"

### PR creator: Due diligence for entity changes

If you request an entity change: Please check all doc repositories for
occurrences of this entity (including all supported maintenance branches).
If there are any side-effects that come with the entity change
(for example, indefinite articles in front of the entity need to be changed
from 'a' to 'an' or vice versa), please fix those in the affected repositories
and branches (after this PR has been accepted and rolled out via doc-kit).

- [ ] all related fixes in the affected doc repositories and branches are done

### PR reviewer: Due diligence for entity changes

In case this PR includes entity changes:

- [ ] I have checked the entity change against our terminology database and found no conflicts



