### PR TITLE
Entities: add missing DB4 entities

### DIFF
--- a/entities/generic-entities.ent
+++ b/entities/generic-entities.ent
@@ -572,10 +572,13 @@ use &deng;! -->
 <!ENTITY nbsp             "&#x000A0;" ><!--NO-BREAK SPACE -->
 <!ENTITY ndash            "&#x02013;" ><!--EN DASH -->
 <!ENTITY rdquo            "&#x0201D;" ><!--RIGHT DOUBLE QUOTATION MARK -->
+<!ENTITY rsquo            "&#x02019;" ><!--RIGHT SINGLE QUOTATION MARK -->
 <!ENTITY reg              "&#x000AE;" ><!--REGISTERED SIG -->
 <!ENTITY sol              "&#x0002F;" ><!--SOLIDUS -->
 <!ENTITY thrdmrk          "*"         ><!--ASTERISK -->
+<!ENTITY times            "&#x000D7;" ><!--MULTIPLICATION SIGN -->
 <!ENTITY trade            "&#x02122;" ><!--TRADE MARK SIGN -->
+<!ENTITY verbar           "&#x0007C;" ><!--VERTICAL LINE -->
 
 <!-- LEGACY COMPATIBILITY ENTITIES -->
 <!-- Do not use in new documentation. -->


### PR DESCRIPTION
### PR creator: Description

The generic-entities.ent file misses some more DB4 entities: 

- rsquo
- times
- verbar

### PR creator: Are there any relevant issues/feature requests?

 The entities are used in the following repositories:

- doc-sleha (see failing GHA for https://github.com/SUSE/doc-sleha/commit/4eef48c23f2ae3229fef64550ed19992a0aecbc3)
- doc-hpc (see failing GHA for https://github.com/SUSE/doc-hpc/commit/85bc81280eefe08d39c33907855e1d18345c6ca9)

### PR creator: In case of entity changes

If you request an entity change: Please check all doc repositories for
occurrences of this entity (including all supported maintenance branches).
If there are any side-effects that come with the entity change you need to fix
those (after this PR has been accepted and rolled out via doc-kit).

- [ ] all related fixes in the affected doc repositories and branches are done

### PR reviewer: Due diligence

- [ ] I have tested the changes in a test repository

In case of entity changes (product names etc.):

- [ ] I have checked the changes against our terminology database and found no conflicts



