### PR TITLE
DC files: add validation with latest GeekoDoc version

### DIFF
--- a/docbook5-book/DC-example
+++ b/docbook5-book/DC-example
@@ -8,5 +8,7 @@ PROFCONDITION="suse-product"
 #PROFCONDITION="suse-product;beta"
 #PROFCONDITION="community-project"
 
+DOCBOOK5_RNG_URI="urn:x-suse:rng:v2:geekodoc-flat"
+
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/smart-doc/_DC-article
+++ b/smart-doc/_DC-article
@@ -11,6 +11,8 @@ PROFCONDITION="suse-product"
 #PROFCONDITION="suse-product;beta"
 #PROFCONDITION="community-project"
 
+DOCBOOK5_RNG_URI="urn:x-suse:rng:v2:geekodoc-flat"
+
 STYLEASSEMBLY="/usr/share/xml/docbook/stylesheet/nwalsh5/current/assembly/assemble.xsl"
 
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"


### PR DESCRIPTION
### PR creator: Description

We recently stumbled across a validation mismatch between local validation and validation with the daps2docker container. Adding one line to the DC files fixes that. 

