### PR TITLE
SuMa -> SMLM (adoc kit)

### DIFF
--- a/entities/generic-attributes.adoc
+++ b/entities/generic-attributes.adoc
@@ -110,12 +110,11 @@ include::product-attributes.adoc[]
 :sleha:                      {sle} {ha}
 :hageo:                      Geo Clustering for {sleha}
 
-// SUSE Manager
-:susemgr:                    {suse} Manager
-:suma:                       {susemgr}
-:susemgrdb:                  {suse} Manager with Database
-:susemgrproxy:               {susemgr} Proxy
-:smr:                        {susemgr} for Retail
+// SUSE Multi-Linux Manager
+:smlm:                    {suse} Multi-Linux Manager
+:smlm-db:                 {smlm} with Database
+:smlm-proxy:              {smlm} Proxy
+:smlm-retail:             {smlm} for Retail
 
 // SUSE PRODUCT ACRONYMS
 :sleda:                      SLED
@@ -135,8 +134,6 @@ include::product-attributes.adoc[]
 :capa:                       SUSE{nbsp}CAP
 :caaspa:                     SUSE{nbsp}CaaSP
 :caspa:                      {caaspa}
-:sumaa:                      SUMA
-:smra:                       SUMA{nbsp}for{nbsp}Retail
 :suseaia:                    {suse} AI
 
 // PRODUCT NAMES WITH (R) SIGN


### PR DESCRIPTION
### PR creator: Description

As the doc-kit for adoc books is [a recent addition](https://github.com/openSUSE/doc-kit/pull/106), this doc-kit is not used in any maintenance branches yet. Therefore the product name change from 'SUSE Manager' to 'SUSE Multi-Linux Manager' was straightforward: replacing the SuMa attributes with new ones, based on the [related change for the DocBook variant](https://github.com/openSUSE/doc-kit/pull/107). No need to keep the old attributes around.


### PR creator: Are there any relevant issues/feature requests?
https://jira.suse.com/browse/DOCTEAM-1754

