### PR TITLE
Update templates for correct metadata/title length

### DIFF
--- a/docbook5-book/xml/MAIN.book-example-cc.xml
+++ b/docbook5-book/xml/MAIN.book-example-cc.xml
@@ -14,10 +14,13 @@
 <book xml:id="book-example" xml:lang="en"
  xmlns="http://docbook.org/ns/docbook" version="5.1"
  xmlns:xi="http://www.w3.org/2001/XInclude"
- xmlns:xlink="http://www.w3.org/1999/xlink">
+ xmlns:xlink="http://www.w3.org/1999/xlink"
+ xmlns:its="http://www.w3.org/2005/11/its">
 
  <info>
-   <title>Example guide</title>
+   <title>Example Guide</title>
+    <!--for SEO reasons: title length between 29-55 chars (incl. whitespace and
+    incl. resolved product names and numbers as listed in the next elements)-->
    <productname>&productname;</productname>
    <productnumber>&productnumber;</productnumber>
    <productname role="abbrev">&productnameshort;</productname>
@@ -38,13 +41,27 @@
     <dm:editurl>GitHub URL (path to xml directory)</dm:editurl>
     <dm:translation>yes</dm:translation>
    </dm:docmanager>
-  <revhistory xml:id="rh-book-example">
-   <revision>
-    <date>2000-01-01</date>
-    <revdescription>
-     <para/>
-    </revdescription>
-   </revision>
+
+   <meta name="title" its:translate="yes">title for SEO/social media, max. 55 chars (incl. whitespace), keep in sync with book title</meta>
+   <meta name="series" its:translate="no">Products &amp; Solutions</meta>
+   <meta name="description" its:translate="yes">short description, max. 155 chars (incl. whitespace), no full stop: How to perform task xyz</meta>
+   <meta name="social-descr" its:translate="yes">ultrashort description for social media, max. 55 chars (incl. whitespace), no full stop: Perform task xyz</meta>
+   <meta name="task" its:translate="no">
+    <!--Used for the 'filter by task' tab on the index pages. Only a fixed set of values is currently supported.
+    You may define multiple entries here.-->
+    <phrase></phrase>
+   </meta>
+
+   <revhistory xml:id="rh-book-example">
+    <!--see https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-revhistory for instructions-->
+    <revision><date>YYYY-MM-DD</date>
+      <revdescription>
+        <!-- briefly sum up the major changes for the reader -->
+        <para>
+          Updated CONTENT, extended CONTENT, removed CONTENT
+        </para>
+      </revdescription>
+    </revision>
   </revhistory>
  </info>
 

--- a/docbook5-book/xml/MAIN.book-example-gfdl.xml
+++ b/docbook5-book/xml/MAIN.book-example-gfdl.xml
@@ -14,10 +14,13 @@
 <book xml:id="book-example" xml:lang="en"
  xmlns="http://docbook.org/ns/docbook" version="5.1"
  xmlns:xi="http://www.w3.org/2001/XInclude"
- xmlns:xlink="http://www.w3.org/1999/xlink">
+ xmlns:xlink="http://www.w3.org/1999/xlink"
+ xmlns:its="http://www.w3.org/2005/11/its">
 
  <info>
-   <title>Example guide</title>
+   <title>Example Guide</title>
+   <!--for SEO reasons: title length between 29-55 chars (incl. whitespace and
+    incl. resolved product names and numbers as listed in the next elements)-->
    <productname>&productname;</productname>
    <productnumber>&productnumber;</productnumber>
    <productname role="abbrev">&productnameshort;</productname>
@@ -38,13 +41,27 @@
     <dm:editurl>GitHub URL (path to xml directory)</dm:editurl>
     <dm:translation>yes</dm:translation>
    </dm:docmanager>
-  <revhistory xml:id="rh-book-example">
-   <revision>
-    <date>2000-01-01</date>
-    <revdescription>
-     <para/>
-    </revdescription>
-   </revision>
+
+   <meta name="title" its:translate="yes">title for SEO/social media, max. 55 chars (incl. whitespace), keep in sync with book title</meta>
+   <meta name="series" its:translate="no">Products &amp; Solutions</meta>
+   <meta name="description" its:translate="yes">short description, max. 155 chars (incl. whitespace), no full stop: How to perform task xyz</meta>
+   <meta name="social-descr" its:translate="yes">ultrashort description for social media, max. 55 chars (incl. whitespace), no full stop: Perform task xyz</meta>
+   <meta name="task" its:translate="no">
+    <!--Used for the 'filter by task' tab on the index pages. Only a fixed set of values is currently supported.
+    You may define multiple entries here.-->
+    <phrase></phrase>
+   </meta>
+
+   <revhistory xml:id="rh-book-example">
+    <!--see https://documentation.suse.com/style/current/html/style-guide-db/sec-smartdocs.html#sec-revhistory for instructions-->
+    <revision><date>YYYY-MM-DD</date>
+      <revdescription>
+        <!-- briefly sum up the major changes for the reader -->
+        <para>
+          Updated CONTENT, extended CONTENT, removed CONTENT
+        </para>
+      </revdescription>
+    </revision>
   </revhistory>
  </info>
 

--- a/smart-doc/articles/assembly.asm.xml
+++ b/smart-doc/articles/assembly.asm.xml
@@ -60,7 +60,7 @@
   <!-- S T R U C T U R E -->
   <structure renderas="article" xml:id="article-example" xml:lang="en">
     <merge>
-      <title>Your title (title style), limit to 55 chars, if possible</title>
+      <title>Your title (title style, min. length: 29 chars, max. length: 55 chars, incl. whitespace)</title>
       <subtitle>Subtitle if necessary</subtitle>
       <!-- Create revision history to enable versioning: adjust the placeholder revhistory ID,
            for each entry add the date of when the updated article will be published,
@@ -94,9 +94,9 @@
       <meta name="productname" its:translate="no">
         <productname version="X.Y">&productname;</productname>
       </meta>
-      <meta name="title" its:translate="yes">title for SEO and social media, max. 55 chars, keep in sync with article title</meta>
-      <meta name="description" its:translate="yes">short description, max. 150 chars, no full stop: How to perform task xyz </meta>
-      <meta name="social-descr" its:translate="yes">ultrashort description for social media, max. 55 chars, no full stop: Perform task xyz</meta>
+      <meta name="title" its:translate="yes">title for SEO/social media, max. 55 chars (incl. whitespace), keep in sync with article title</meta>
+      <meta name="description" its:translate="yes">short description, max. 155 chars (incl. whitespace), no full stop: How to perform task xyz</meta>
+      <meta name="social-descr" its:translate="yes">ultrashort description for social media, max. 55 chars (incl. whitespace), no full stop: Perform task xyz</meta>
       <!-- suitable categories has to be identical with the category selected in the docserv config -->
       <meta name="category" its:translate="no">
         <phrase>Systems Management</phrase>

--- a/smart-doc/articles/assembly.asm.xml
+++ b/smart-doc/articles/assembly.asm.xml
@@ -60,7 +60,7 @@
   <!-- S T R U C T U R E -->
   <structure renderas="article" xml:id="article-example" xml:lang="en">
     <merge>
-      <title>Your title (title style, min. length: 29 chars, max. length: 55 chars, incl. whitespace)</title>
+      <title>Your title (spelling: title style, length: 29-55 chars incl. whitespace)</title>
       <subtitle>Subtitle if necessary</subtitle>
       <!-- Create revision history to enable versioning: adjust the placeholder revhistory ID,
            for each entry add the date of when the updated article will be published,


### PR DESCRIPTION
### PR creator: Description

The recent localization drops revealed some issues with regards to character limitations for metadata and title length.

Updated the templates for two kits according to the latest agreements: 

-  [smart-doc](https://github.com/openSUSE/doc-kit/tree/main/smart-doc)
-  [docbook5-book](https://github.com/openSUSE/doc-kit/tree/main/docbook5-book)

For the latter, metadata elements had been missing altogether -> added those. 

## Related info

https://github.com/SUSE/doc-styleguide/pull/330
https://github.com/openSUSE/suse-xsl/issues/737

