### PR TITLE
Changed entity values to lowercase as per convention

### DIFF
--- a/entities/generic-entities.ent
+++ b/entities/generic-entities.ent
@@ -473,22 +473,22 @@ use &deng;! -->
 <!ENTITY amdsev                 "AMD SEV">
 <!ENTITY dom0                   "Dom0">
 <!ENTITY esx                    "&vmware; ESX">
-<!ENTITY gpuback                "GPU Pass-Through">
+<!ENTITY gpuback                "GPU pass-through">
 <!ENTITY hyperv                 "&ms; Hyper-V">
 <!ENTITY kvm                    "KVM">
 <!ENTITY kvmserver              "&kvm; Server">
 <!ENTITY kvmclient              "&kvm; Client">
 <!ENTITY libvirt                "<systemitem xmlns='http://docbook.org/ns/docbook' class='library'>libvirt</systemitem>">
-<!ENTITY pciback                "PCI Pass-Through">
+<!ENTITY pciback                "PCI pass-through">
 <!ENTITY qemu                   "QEMU">
 <!ENTITY qemusystemarch         "<command xmlns='http://docbook.org/ns/docbook'>qemu-system-<replaceable>ARCH</replaceable></command>">
-<!ENTITY usbback                "USB Pass-Through">
+<!ENTITY usbback                "USB pass-through">
 <!ENTITY vagrant                "Vagrant">
 <!ENTITY vagrantfile            "<filename xmlns='http://docbook.org/ns/docbook'>Vagrantfile</filename>">
 <!ENTITY vbox                   "VirtualBox">
 <!ENTITY virtualbox             "&vbox;">
 <!ENTITY virsh                  "<command xmlns='http://docbook.org/ns/docbook'>virsh</command>">
-<!ENTITY vgaback                "VGA Pass-Through">
+<!ENTITY vgaback                "VGA pass-through">
 <!ENTITY vmguest                "VM Guest">
 <!ENTITY vmhost                 "VM Host Server">
 <!ENTITY vmm                    "Virtual Machine Manager">


### PR DESCRIPTION
### PR creator: Description

Changed entity values to lowercase, as per convention:
`<!ENTITY gpuback        "GPU pass-through">`
`<!ENTITY pciback        "PCI pass-through">`
`<!ENTITY usbback        "USB pass-through">`
`<!ENTITY vgaback        "VGA pass-through">`

The earlier ones with sentence case was introduced in:
- `pciback`, `usbback`, and `vgaback` were introduced in there sentence-case form in https://github.com/openSUSE/doc-kit/commit/6c1d39fa5ba5467fd6a035f3ca77dfb46f528ea0 
- `gpuback` was introduced in it's sentence case form in https://github.com/openSUSE/doc-kit/commit/741fee69587209f9f7ae612024ce2d242c71e9b4


### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#...

### PR creator: In case of entity changes

If you request an entity change: Please check all doc repositories for
occurrences of this entity (including all supported maintenance branches).
If there are any side-effects that come with the entity change you need to fix
those (after this PR has been accepted and rolled out via doc-kit).

- [ ] all related fixes in the affected doc repositories and branches are done

### PR reviewer: Due diligence

- [ ] I have tested the changes in a test repository

In case of entity changes (product names etc.):

- [ ] I have checked the changes against our terminology database and found no conflicts



