### PR TITLE
Merge hardware-related attributes from SUSE release-notes.git

### DIFF
--- a/entities/generic-attributes.adoc
+++ b/entities/generic-attributes.adoc
@@ -295,6 +295,8 @@ include::../common/network-attributes.adoc[]
 :altrareg:                   {altra}{thrdmrk}
 :altramax:                   Altra{nbsp}Max
 :altramaxreg:                {altramax}{thrdmrk}
+:ampereone:                  AmpereOne
+:ampereonereg:               {ampereone}{thrdmrk}
 // https://www.amd.com/en/corporate/trademarks
 :amd:                        AMD
 :amdreg:                     {amd}{thrdmrk}

--- a/entities/generic-attributes.adoc
+++ b/entities/generic-attributes.adoc
@@ -365,11 +365,23 @@ include::../common/network-attributes.adoc[]
 :mipicsi2:                   {mipi}{nbsp}CSI{nbh}2
 :mipicsi2reg:                {mipireg}{nbsp}CSI{nbh}2{thrdmrk}
 // https://www.nvidia.com/en-us/about-nvidia/legal-info/
+:cuda:                       CUDA
+:cudareg:                    {cuda}{thrdmrk}
+:jetson:                     Jetson
+:jetsonreg:                  {jetson}{thrdmrk}
+:jetpack:                    JetPack
+:jetpackreg:                 {jetpack}{thrdmrk}
+:xavier:                     Xavier
+:xavierreg:                  {xavier}{thrdmrk}
+:jetsonagxxavier:            Jetson AGX{nbsp}Xavier
+:jetsonagxxavierreg:         {jetsonagxxavier}{thrdmrk}
+:orin:                       Orin
+:orinreg:                    {orin}{thrdmrk}
+:thor:                       Thor
+:thorreg:                    {thor}{thrdmrk}
 :drive:                      DRIVE
 :nvidiadrive:                NVIDIA {drive}
 :nvidiadrivereg:             {nvidiadrive}{thrdmrk}
-:jetsonagxxavier:            Jetson AGX{nbsp}Xavier
-:jetsonagxxavierreg:         {jetsonagxxavier}{thrdmrk}
 :pegasus:                    Pegasus
 :pegasusreg:                 {pegasus}{thrdmrk}
 // https://www.nxp.com/company/our-company/about-nxp/terms-of-use:TERMSOFUSE
@@ -400,20 +412,6 @@ include::../common/network-attributes.adoc[]
 :ultrascalereg:              {ultrascale}{thrdmrk}
 :zynq:                       Zynq
 :zynqreg:                    {zynq}{thrdmrk}
-
-// NVIDIA products
-:cuda:                       CUDA
-:cudareg:                    {cuda}{thrdmrk}
-:jetson:                     Jetson
-:jetsonreg:                  {jetson}{thrdmrk}
-:jetpack:                    JetPack
-:jetpackreg:                 {jetpack}{thrdmrk}
-:xavier:                     Xavier
-:xavierreg:                  {xavier}{thrdmrk}
-:orin:                       Orin
-:orinreg:                    {orin}{thrdmrk}
-:thor:                       Thor
-:thorreg:                    {thor}{thrdmrk}
 
 // SYSTEM COMPONENTS
 :ds389:                      389 Directory Server

--- a/entities/generic-attributes.adoc
+++ b/entities/generic-attributes.adoc
@@ -189,8 +189,8 @@ include::../common/network-attributes.adoc[]
 :x86-64:                     {amd64}/{intel64}
 :arm:                        Arm
 :armreg:                     Arm{thrdmrk}
-:armv7:                      Armv7
-:armv8:                      Armv8
+:armv7:                      {arm}{nbzwsp}v7
+:armv8:                      {arm}{nbzwsp}v8
 :aarch64:                    AArch64
 :arm64:                      {arm}{nbsp}{aarch64}
 :cortex:                     {arm}{nbsp}Cortex
@@ -301,7 +301,6 @@ include::../common/network-attributes.adoc[]
 :opteron:                    Opteron
 :opteronreg:                 {opteron}{thrdmrk}
 // https://www.arm.com/company/policies/trademarks
-:armv8:                      {arm}{nbzwsp}v8
 :mali:                       Mali
 :malireg:                    {mali}{thrdmrk}
 :neoverse:                   Neoverse

--- a/entities/generic-attributes.adoc
+++ b/entities/generic-attributes.adoc
@@ -369,16 +369,26 @@ include::../common/network-attributes.adoc[]
 // https://www.nvidia.com/en-us/about-nvidia/legal-info/
 :cuda:                       CUDA
 :cudareg:                    {cuda}{thrdmrk}
+:grace:                      Grace
+:gracehopper:                {grace} Hopper
+:nvidiagrace:                NVIDIA {grace}
+:nvidiagracereg:             {nvidiagrace}{thrdmrk}
+:nvidiagracehopper:          NVIDIA {gracehopper}
+:nvidiagracehopperreg:       {nvidiagracehopper}{thrdmrk}
 :jetson:                     Jetson
 :jetsonreg:                  {jetson}{thrdmrk}
 :jetpack:                    JetPack
 :jetpackreg:                 {jetpack}{thrdmrk}
+:tegra:                      Tegra
+:tegrareg:                   {tegra}{thrdmrk}
 :xavier:                     Xavier
 :xavierreg:                  {xavier}{thrdmrk}
 :jetsonagxxavier:            Jetson AGX{nbsp}Xavier
 :jetsonagxxavierreg:         {jetsonagxxavier}{thrdmrk}
 :orin:                       Orin
 :orinreg:                    {orin}{thrdmrk}
+:nvidiaorin:                 NVIDIA {orin}
+:nvidiaorinreg:              {nvidiaorin}{thrdmrk}
 :thor:                       Thor
 :thorreg:                    {thor}{thrdmrk}
 :drive:                      DRIVE

--- a/entities/generic-entities.ent
+++ b/entities/generic-entities.ent
@@ -811,19 +811,19 @@ use &deng;! -->
 <!ENTITY mipicsi2reg "&mipireg;&nbsp;CSI&nbh;2&thrdmrk;">
 <!-- https://www.nvidia.com/en-us/about-nvidia/legal-info/ -->
 <!ENTITY cuda                   "CUDA">
-<!ENTITY cudareg                "&cuda;*">
+<!ENTITY cudareg                "&cuda;&thrdmrk;">
 <!ENTITY jetson                 "Jetson">
-<!ENTITY jetsonreg              "&jetson;*">
+<!ENTITY jetsonreg              "&jetson;&thrdmrk;">
 <!ENTITY jetpack                "JetPack">
-<!ENTITY jetpackreg             "&jetpack;*">
+<!ENTITY jetpackreg             "&jetpack;&thrdmrk;">
 <!ENTITY xavier                 "Xavier">
-<!ENTITY xavierreg              "&xavier;*">
+<!ENTITY xavierreg              "&xavier;&thrdmrk;">
 <!ENTITY jetsonagxxavier        "Jetson AGX&nbsp;Xavier">
 <!ENTITY jetsonagxxavierreg     "&jetsonagxxavier;&thrdmrk;">
 <!ENTITY orin                   "Orin">
-<!ENTITY orinreg                "&orin;*">
+<!ENTITY orinreg                "&orin;&thrdmrk;">
 <!ENTITY thor                   "Thor">
-<!ENTITY thorreg                "&thor;*">
+<!ENTITY thorreg                "&thor;&thrdmrk;">
 <!ENTITY drive "DRIVE">
 <!ENTITY nvidiadrive "NVIDIA &drive;">
 <!ENTITY nvidiadrivereg "&nvidiadrive;&thrdmrk;">

--- a/entities/generic-entities.ent
+++ b/entities/generic-entities.ent
@@ -311,8 +311,8 @@ use &deng;! -->
 
 <!ENTITY arm                    "Arm">
 <!ENTITY armreg                 "Arm*">
-<!ENTITY armv7                  "Armv7">
-<!ENTITY armv8                  "Armv8">
+<!ENTITY armv7                  "&arm;&nbzwsp;v7">
+<!ENTITY armv8                  "&arm;&nbzwsp;v8">
 <!ENTITY aarch64                "AArch64">
 <!ENTITY arm64                  "&arm;&nbsp;&aarch64;">
 <!ENTITY cortex                 "&arm;&nbsp;Cortex">
@@ -760,7 +760,6 @@ use &deng;! -->
 <!ENTITY opteron "Opteron">
 <!ENTITY opteronreg "&opteron;&thrdmrk;">
 <!-- https://www.arm.com/company/policies/trademarks -->
-<!ENTITY armv8 "&arm;&nbzwsp;v8">
 <!ENTITY mali "Mali">
 <!ENTITY malireg "&mali;&thrdmrk;">
 <!ENTITY neoverse "Neoverse">

--- a/entities/generic-entities.ent
+++ b/entities/generic-entities.ent
@@ -272,20 +272,6 @@ use &deng;! -->
 
 
 
-<!-- NVIDIA products -->
-<!ENTITY cuda                   "CUDA">
-<!ENTITY cudareg                "&cuda;*">
-<!ENTITY jetson                 "Jetson">
-<!ENTITY jetsonreg              "&jetson;*">
-<!ENTITY jetpack                "JetPack">
-<!ENTITY jetpackreg             "&jetpack;*">
-<!ENTITY xavier                 "Xavier">
-<!ENTITY xavierreg              "&xavier;*">
-<!ENTITY orin                   "Orin">
-<!ENTITY orinreg                "&orin;*">
-<!ENTITY thor                   "Thor">
-<!ENTITY thorreg                "&thor;*">
-
 <!-- SLE DVD IMAGE NAMES -->
 
 <!ENTITY allmodules             "SLE-15-Packages">
@@ -824,11 +810,23 @@ use &deng;! -->
 <!ENTITY mipicsi2 "&mipi;&nbsp;CSI&nbh;2">
 <!ENTITY mipicsi2reg "&mipireg;&nbsp;CSI&nbh;2&thrdmrk;">
 <!-- https://www.nvidia.com/en-us/about-nvidia/legal-info/ -->
+<!ENTITY cuda                   "CUDA">
+<!ENTITY cudareg                "&cuda;*">
+<!ENTITY jetson                 "Jetson">
+<!ENTITY jetsonreg              "&jetson;*">
+<!ENTITY jetpack                "JetPack">
+<!ENTITY jetpackreg             "&jetpack;*">
+<!ENTITY xavier                 "Xavier">
+<!ENTITY xavierreg              "&xavier;*">
+<!ENTITY jetsonagxxavier        "Jetson AGX&nbsp;Xavier">
+<!ENTITY jetsonagxxavierreg     "&jetsonagxxavier;&thrdmrk;">
+<!ENTITY orin                   "Orin">
+<!ENTITY orinreg                "&orin;*">
+<!ENTITY thor                   "Thor">
+<!ENTITY thorreg                "&thor;*">
 <!ENTITY drive "DRIVE">
 <!ENTITY nvidiadrive "NVIDIA &drive;">
 <!ENTITY nvidiadrivereg "&nvidiadrive;&thrdmrk;">
-<!ENTITY jetsonagxxavier "Jetson AGX&nbsp;Xavier">
-<!ENTITY jetsonagxxavierreg "&jetsonagxxavier;&thrdmrk;">
 <!ENTITY pegasus "Pegasus">
 <!ENTITY pegasusreg "&pegasus;&thrdmrk;">
 <!-- https://www.nxp.com/company/our-company/about-nxp/terms-of-use:TERMSOFUSE -->


### PR DESCRIPTION
### PR creator: Description

* Fix a duplicate `armv8` attribute/entity and adjust `armv7` while at it
* Merge two separate file locations for NVIDIA attributes/entities
* Add all attributes from https://github.com/SUSE/release-notes/blob/main/adoc/common/attributes-generic.adoc `Hardware/Architecture attributes` section (Ampere Computing, NVIDIA) -- not needed as entities for now
* Consistently use `{thrdmrk}` / `&thrdmrk;`

### PR creator: Are there any relevant issues/feature requests?

no (but future feature PRs to be based on this)

### PR creator: In case of entity changes

If you request an entity change: Please check all doc repositories for
occurrences of this entity (including all supported maintenance branches).
If there are any side-effects that come with the entity change you need to fix
those (after this PR has been accepted and rolled out via doc-kit).

- [ ] all related fixes in the affected doc repositories and branches are done
- [ ] https://github.com/SUSE/release-notes/blob/main/adoc/common/attributes-generic.adoc should get the section removed once imported via the main section above.

### PR reviewer: Due diligence

- [ ] I have tested the changes in a test repository

In case of entity changes (product names etc.):

- [ ] I have checked the changes against our terminology database and found no conflicts



